### PR TITLE
feat: add new `edit` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,22 @@ Full directive text, BAD/GOOD example pairs, and rationale per rule: see `.agent
 ## Code style
 
 - Only comment non-obvious code — hidden constraints, subtle invariants, workarounds. If a future reader would not be confused by the comment's absence, leave it out.
-- Do not record conversation history, decisions, or task context in comments. That belongs in the commit message or PR description.
+- Do not record conversation history, decisions, or task context in comments.
 - Keep function and class header comments terse. No more than a paragraph.
 - Name identifiers so the code explains itself; rename rather than annotate.
+- Follow the "Rule of Three" as a guidepost for factoring out shared logic.
+- Break out long functions in to multiple smaller testable units once they exceed a few hundred lines of code. Command entry points can be a bit longer than other functions.
 - Emphasis on consistency of patterns across the codebase, except where clarity for other devs would be improved by diverging from a pattern.
+
+### Logging and Exceptions
+
+Every module should get and use its own `logger` for all logging purposes and follow semantic best practices of log levels:
+
+- `debug` logs should be used to record relevant application state at significant logic branches and points of execution. These are not printed to the user unless the `--print debug` option is provided.
+- `info` logs are the primary means of showing output to the user, and should be used sparingly/as necessary.
+- `warning` logs communicate potential issues with application state or dangerous/unexpected circumstances that do not prevent execution from continuing.
+- `error` logs communicate that invalid application or system state was encountered and needs attention, or invalid input was given, and execution cannot continue.
+- `critical` logs communicate that an unexpected/unstable state was reached and execution was interrupted.
 
 ## Testing
 
@@ -76,7 +88,9 @@ Full directive text, BAD/GOOD example pairs, and rationale per rule: see `.agent
 
 - Implement the smallest functional slice first, then layer features in follow-up commits. Each commit should be "green" and independently deployable.
 - Follow Conventional Commits (see `CONTRIBUTING.md` and the schema in `pyproject.toml`). No `Co-Authored-By` trailer.
-- Claude commits. The user pushes, opens PRs, and rebases after merges.
+- Commit descriptions should be terse and use active tenses (e.g. "add feature")
+- Commit bodies should describe changes, but should not include agent conversation context, decisions, or plan notes.
+- The agent may commit. But the user always handles pushes, PR creation, and rebases after merges.
 - Do not commit spec, brainstorming, or design documents (e.g. anything under `docs/superpowers/specs/`).
 
 ## Tooling

--- a/rekordbox_edit/cli.py
+++ b/rekordbox_edit/cli.py
@@ -7,6 +7,7 @@ import sys
 import click
 
 from rekordbox_edit.commands.convert import convert_command
+from rekordbox_edit.commands.edit import edit_command
 from rekordbox_edit.commands.search import search_command
 from rekordbox_edit.logger import get_debug_file_path, setup_logging
 
@@ -23,9 +24,8 @@ def cli():
 
 
 cli.add_command(search_command)
-cli.add_command(
-    convert_command,
-)
+cli.add_command(convert_command)
+cli.add_command(edit_command)
 
 
 def main():

--- a/rekordbox_edit/commands/edit.py
+++ b/rekordbox_edit/commands/edit.py
@@ -1,0 +1,175 @@
+"""Edit command for rekordbox-edit."""
+
+import logging
+import sys
+from typing import List
+
+import click
+from pyrekordbox import Rekordbox6Database
+
+from rekordbox_edit._click import (
+    PrintChoice,
+    add_click_options,
+    global_click_filters,
+    print_option,
+    track_ids_argument,
+)
+from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.query import get_filtered_content
+from rekordbox_edit.utils import UserQuit, confirm, print_track_info
+
+logger = logging.getLogger(__name__)
+
+# Maps CLI field names to DjmdContent column attribute names.
+FIELD_COLUMNS = {
+    "Title": "Title",
+}
+
+
+
+@click.command(
+    epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
+)
+@add_click_options([*global_click_filters, print_option])
+@click.option(
+    "--interactive",
+    "-i",
+    is_flag=True,
+    help="Confirm each track individually before editing",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would change without writing to the database",
+)
+@click.option(
+    "--replace",
+    "replace_value",
+    required=True,
+    help="The new value to write to the field",
+)
+@track_ids_argument
+@click.argument(
+    "field",
+    type=click.Choice(list(FIELD_COLUMNS.keys()), case_sensitive=False),
+)
+def edit_command(
+    field: str,
+    replace_value: str,
+    dry_run: bool,
+    yes: bool,
+    interactive: bool,
+    track_ids: tuple,
+    track_id: List[str] | None,
+    playlist: List[str] | None,
+    exact_playlist: List[str] | None,
+    album: List[str] | None,
+    exact_album: List[str] | None,
+    artist: List[str] | None,
+    exact_artist: List[str] | None,
+    title: List[str] | None,
+    exact_title: List[str] | None,
+    path: List[str] | None,
+    exact_path: List[str] | None,
+    format: List[str] | None,
+    match_all: bool,
+    print_opt: PrintChoice | None,
+):
+    """Edit a metadata field on tracks in the RekordBox database."""
+
+    set_level(print_opt)
+
+    piped_stdin = False
+    if not sys.stdin.isatty():
+        stdin_data = sys.stdin.read().strip()
+        if stdin_data:
+            piped_stdin = True
+            track_ids = list(track_ids or []) + stdin_data.split()
+
+    scripting_mode = print_opt in (PrintChoice.IDS, PrintChoice.SILENT)
+    if scripting_mode and not (dry_run or yes):
+        raise click.UsageError(
+            "--print=ids or --print=silent requires --dry-run or --yes to skip confirmation"
+        )
+
+    if piped_stdin and not (dry_run or yes):
+        raise click.UsageError(
+            "Piping track IDs into edit requires --dry-run or --yes"
+        )
+
+    db = Rekordbox6Database()
+    if not db.session:
+        raise RuntimeError("Failed to connect to Rekordbox Database: No Session.")
+
+    result = get_filtered_content(
+        db,
+        track_id_args=track_ids,
+        track_ids=track_id,
+        playlists=playlist,
+        exact_playlists=exact_playlist,
+        artists=artist,
+        exact_artists=exact_artist,
+        albums=album,
+        exact_albums=exact_album,
+        titles=title,
+        exact_titles=exact_title,
+        paths=path,
+        exact_paths=exact_path,
+        formats=format,
+        match_all=match_all,
+    )
+    tracks = result.scalars().all()
+
+    col_name = FIELD_COLUMNS[field]
+    edits = [
+        (track, replace_value)
+        for track in tracks
+        if getattr(track, col_name) != replace_value
+    ]
+
+    if not edits:
+        logger.info("No changes to make.")
+        return
+
+    if len(edits) > 1:
+        raise click.UsageError(
+            f"Found {len(edits)} tracks that would be edited. "
+            "Refine your filters, or use --dry-run to inspect."
+        )
+
+    print_track_info([t for t, _ in edits])
+
+    if dry_run:
+        if print_opt is PrintChoice.IDS:
+            print(" ".join(str(t.ID) for t, _ in edits))
+        return
+
+    if not yes and not interactive:
+        try:
+            if not confirm(f"Apply {len(edits)} edit(s)?", default=True):
+                logger.info("Cancelled.")
+                return
+        except UserQuit:
+            return
+
+    for track, new_value in edits:
+        if interactive and not yes:
+            try:
+                if not confirm(f"  Edit {track.ID}?", default=True):
+                    continue
+            except UserQuit:
+                logger.info("Cancelled.")
+                return
+        setattr(track, col_name, new_value)
+
+    db.session.commit()
+    logger.info(f"Applied {len(edits)} edit(s).")
+
+    if print_opt is PrintChoice.IDS:
+        print(" ".join(str(t.ID) for t, _ in edits))

--- a/ruff.toml
+++ b/ruff.toml
@@ -44,9 +44,10 @@ select = [
   "E7",
   "E9",
   "F",
-  "W" ,
-  # "C901"
+  "W",
+  "C90",
 ]
+
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -55,6 +56,9 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.mccabe]
+max-complexity = 50
 
 [format]
 # Like Black, use double quotes for strings.

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -207,6 +207,28 @@ class TestEditCommandPhase1:
     @patch("rekordbox_edit.commands.edit.confirm")
     @patch("rekordbox_edit.commands.edit.get_filtered_content")
     @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_interactive_and_yes_skips_all_confirms(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--interactive + --yes skips both batch and per-track confirms."""
+        track = make_djmd_content_item(Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command,
+            ["Title", "--replace", "New Title", "--interactive", "--yes"],
+        )
+
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
     def test_print_ids_outputs_edited_track_ids(
         self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
     ):

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,0 +1,226 @@
+"""Unit tests for edit command."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rekordbox_edit.commands.edit import edit_command
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    with patch("rekordbox_edit.commands.edit.logger") as mock_log:
+        yield mock_log
+
+
+def _make_db_and_result(tracks):
+    """Return (mock_db_class, mock_get_filtered_content) with given tracks."""
+    mock_db = Mock()
+    mock_db.session = Mock()
+    mock_result = Mock()
+    mock_result.scalars.return_value.all.return_value = tracks
+    return mock_db, mock_result
+
+
+class TestEditCommandPhase1:
+    """Phase 1: Title field, wholesale replace, single-track guard, confirm flow."""
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_sets_title_and_commits(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--replace sets the field on the matched track and commits the session."""
+        track = make_djmd_content_item(Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+        mock_confirm.return_value = True
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New Title"])
+
+        assert result.exit_code == 0
+        assert track.Title == "New Title"
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_noop_tracks_are_skipped(
+        self, mock_db_class, mock_gfc, make_djmd_content_item
+    ):
+        """Tracks whose current value already equals --replace are not committed."""
+        track = make_djmd_content_item(Title="Same Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "Same Title", "--yes"])
+
+        assert result.exit_code == 0
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_single_track_guard_aborts_on_multiple_matches(
+        self, mock_db_class, mock_gfc, make_djmd_content_item
+    ):
+        """When >1 track would change and --multi is absent, exit with non-zero code."""
+        tracks = [
+            make_djmd_content_item(Title="Track A"),
+            make_djmd_content_item(Title="Track B"),
+        ]
+        mock_db, mock_result = _make_db_and_result(tracks)
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        assert result.exit_code != 0
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_dry_run_does_not_commit(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--dry-run shows preview but does not write to the database."""
+        track = make_djmd_content_item(Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New Title", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_db.session.commit.assert_not_called()
+        mock_confirm.assert_not_called()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_yes_skips_confirm(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--yes applies changes without prompting."""
+        track = make_djmd_content_item(Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New Title", "--yes"])
+
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_interactive_confirms_each_track(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--interactive prompts per track (skipping the batch prompt)."""
+        track = make_djmd_content_item(Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+        mock_confirm.return_value = True
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New Title", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        mock_confirm.assert_called_once()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_piped_stdin_requires_yes_or_dry_run(self, mock_db_class, mock_gfc):
+        """Piping track IDs into edit without --yes or --dry-run is rejected."""
+        mock_db = Mock()
+        mock_db.session = Mock()
+        mock_db_class.return_value = mock_db
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New Title"], input="12345"
+        )
+
+        assert result.exit_code != 0
+
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_scripting_mode_requires_yes_or_dry_run(self, mock_db_class, mock_gfc):
+        """--print=ids without --yes or --dry-run is rejected."""
+        mock_db = Mock()
+        mock_db.session = Mock()
+        mock_db_class.return_value = mock_db
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New Title", "--print", "ids"]
+        )
+
+        assert result.exit_code != 0
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_filters_forwarded_to_get_filtered_content(
+        self, mock_db_class, mock_gfc, mock_confirm
+    ):
+        """All global filter flags are forwarded to get_filtered_content."""
+        mock_db = Mock()
+        mock_db.session = Mock()
+        mock_db_class.return_value = mock_db
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        CliRunner().invoke(
+            edit_command,
+            [
+                "Title",
+                "--replace", "New Title",
+                "--artist", "Bicep",
+                "--format", "flac",
+                "--match-all",
+                "--yes",
+            ],
+        )
+
+        kwargs = mock_gfc.call_args.kwargs
+        assert kwargs["artists"] == ("Bicep",)
+        assert kwargs["formats"] == ("flac",)
+        assert kwargs["match_all"] is True
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_print_ids_outputs_edited_track_ids(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--print=ids outputs the IDs of edited tracks after committing."""
+        track = make_djmd_content_item(ID="99999", Title="Old Title")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command,
+            ["Title", "--replace", "New Title", "--print", "ids", "--yes"],
+        )
+
+        assert result.exit_code == 0
+        assert "99999" in result.output


### PR DESCRIPTION
Beginning of #17.

Start with a positional `field` argument that must match the name of a supported [PyRekordbox `DjmdContent` column](https://pyrekordbox.readthedocs.io/en/stable/formats/db6.html#djmdcontent). In this first pass it's just `Title` that's supported. Also requires a `--replace` argument that specifies the value to replace the field wholesale with.