### PR TITLE
feat(edit): add --multi to allow batch edits past single-track guard

### DIFF
--- a/rekordbox_edit/commands/edit.py
+++ b/rekordbox_edit/commands/edit.py
@@ -73,6 +73,11 @@ def _compute_new_value(
     metavar="PATTERN",
     help="Find this literal string within the field value and replace only that portion",
 )
+@click.option(
+    "--multi",
+    is_flag=True,
+    help="Allow editing more than one track (required when filters match multiple tracks)",
+)
 @track_ids_argument
 @click.argument(
     "field",
@@ -82,6 +87,7 @@ def edit_command(
     field: str,
     replace_value: str,
     match_pattern: str | None,
+    multi: bool,
     dry_run: bool,
     yes: bool,
     interactive: bool,
@@ -157,10 +163,10 @@ def edit_command(
         logger.info("No changes to make.")
         return
 
-    if len(edits) > 1:
+    if len(edits) > 1 and not multi:
         raise click.UsageError(
             f"Found {len(edits)} tracks that would be edited. "
-            "Refine your filters, or use --dry-run to inspect."
+            "Refine your filters, use --dry-run to inspect, or pass --multi to edit all."
         )
 
     print_track_info([t for t, _ in edits])

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -427,3 +427,104 @@ class TestEditCommandUnicode:
 
         assert result.exit_code == 0
         mock_db.session.commit.assert_not_called()
+
+
+class TestEditCommandPhase4:
+    """Phase 4: --multi flag to allow batch edits past the single-track guard."""
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_multi_allows_editing_multiple_tracks(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--multi bypasses the single-track guard and edits all matched tracks."""
+        tracks = [
+            make_djmd_content_item(Title="Track A (feat. X)"),
+            make_djmd_content_item(Title="Track B (feat. Y)"),
+        ]
+        mock_db, mock_result = _make_db_and_result(tracks)
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+        mock_confirm.return_value = True
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command,
+            ["Title", "--match", "feat.", "--replace", "ft.", "--multi"],
+        )
+
+        assert result.exit_code == 0
+        assert tracks[0].Title == "Track A (ft. X)"
+        assert tracks[1].Title == "Track B (ft. Y)"
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_without_multi_still_aborts_on_multiple(
+        self, mock_db_class, mock_gfc, make_djmd_content_item
+    ):
+        """Without --multi, the single-track guard still aborts on multiple matches."""
+        tracks = [
+            make_djmd_content_item(Title="Track A"),
+            make_djmd_content_item(Title="Track B"),
+        ]
+        mock_db, mock_result = _make_db_and_result(tracks)
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes"]
+        )
+
+        assert result.exit_code != 0
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_multi_with_yes_skips_confirm(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--multi --yes edits multiple tracks without prompting."""
+        tracks = [
+            make_djmd_content_item(Title="Track A"),
+            make_djmd_content_item(Title="Track B"),
+        ]
+        mock_db, mock_result = _make_db_and_result(tracks)
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command,
+            ["Title", "--replace", "New", "--multi", "--yes"],
+        )
+
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.commands.edit.confirm")
+    @patch("rekordbox_edit.commands.edit.get_filtered_content")
+    @patch("rekordbox_edit.commands.edit.Rekordbox6Database")
+    def test_multi_single_track_still_works(
+        self, mock_db_class, mock_gfc, mock_confirm, make_djmd_content_item
+    ):
+        """--multi with only one matching track works fine (guard is not inverted)."""
+        track = make_djmd_content_item(Title="Only Track")
+        mock_db, mock_result = _make_db_and_result([track])
+        mock_db_class.return_value = mock_db
+        mock_gfc.return_value = mock_result
+        mock_confirm.return_value = True
+
+        from click.testing import CliRunner
+        result = CliRunner().invoke(
+            edit_command,
+            ["Title", "--replace", "New Title", "--multi"],
+        )
+
+        assert result.exit_code == 0
+        assert track.Title == "New Title"
+        mock_db.session.commit.assert_called_once()


### PR DESCRIPTION
If you wanna risk it for the biscuit, `--multi` won't stop you