### PR TITLE
refactor(display): extract print_track_info into display module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Every module should get and use its own `logger` for all logging purposes and fo
 - Implement the smallest functional slice first, then layer features in follow-up commits. Each commit should be "green" and independently deployable.
 - Follow Conventional Commits (see `CONTRIBUTING.md` and the schema in `pyproject.toml`). No `Co-Authored-By` trailer.
 - Commit descriptions should be terse and use active tenses (e.g. "add feature")
-- Commit bodies should describe changes, but should not include agent conversation context, decisions, or plan notes.
+- Commit bodies are completely optional, and should be used to describe changes when they aren't easily inferred by the main message, they should not include agent conversation context, decisions, or plan notes.
 - The agent may commit. But the user always handles pushes, PR creation, and rebases after merges.
 - Do not commit spec, brainstorming, or design documents (e.g. anything under `docs/superpowers/specs/`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "ffmpeg-python>=0.2.0",
     "click>=8.0.0,<=9.0.0",
     "platformdirs>=4.3.8,<5.0.0",
+    "rich>=13.0.0,<15.0.0",
 ]
 
 [dependency-groups]

--- a/rekordbox_edit/commands/convert.py
+++ b/rekordbox_edit/commands/convert.py
@@ -22,6 +22,7 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.query import get_filtered_content
+from rekordbox_edit.display import print_track_info
 from rekordbox_edit.utils import (
     OutputFormats,
     UserQuit,
@@ -30,7 +31,6 @@ from rekordbox_edit.utils import (
     get_extension_for_format,
     get_file_type_for_format,
     get_file_type_name,
-    print_track_info,
 )
 
 logger = logging.getLogger(__name__)

--- a/rekordbox_edit/commands/convert.py
+++ b/rekordbox_edit/commands/convert.py
@@ -22,7 +22,7 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.query import get_filtered_content
-from rekordbox_edit.display import print_track_info
+from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.utils import (
     OutputFormats,
     UserQuit,
@@ -456,7 +456,11 @@ def convert_command(
         logger.info(
             f"Found {len(files_to_process)} files to convert to {format_out.upper()}"
         )
-        print_track_info(files_to_process)
+        print_track_info(
+            files_to_process,
+            changed_field=PrintableField.FileType,
+            new_values=[format_out.upper()] * len(files_to_process),
+        )
 
         if dry_run:
             if print_opt is PrintChoice.IDS:

--- a/rekordbox_edit/commands/edit.py
+++ b/rekordbox_edit/commands/edit.py
@@ -16,7 +16,8 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.query import get_filtered_content
-from rekordbox_edit.utils import UserQuit, confirm, print_track_info
+from rekordbox_edit.display import print_track_info
+from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 

--- a/rekordbox_edit/commands/edit.py
+++ b/rekordbox_edit/commands/edit.py
@@ -16,7 +16,7 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.query import get_filtered_content
-from rekordbox_edit.display import print_track_info
+from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
@@ -170,7 +170,11 @@ def edit_command(
             "Refine your filters, use --dry-run to inspect, or pass --multi to edit all."
         )
 
-    print_track_info([t for t, _ in edits])
+    print_track_info(
+        [t for t, _ in edits],
+        changed_field=PrintableField[field],
+        new_values=[str(v) for _, v in edits],
+    )
 
     if dry_run:
         if print_opt is PrintChoice.IDS:

--- a/rekordbox_edit/commands/search.py
+++ b/rekordbox_edit/commands/search.py
@@ -16,9 +16,7 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.query import get_filtered_content
-from rekordbox_edit.utils import (
-    print_track_info,
-)
+from rekordbox_edit.display import print_track_info
 
 logger = logging.getLogger(__name__)
 

--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -94,8 +94,24 @@ def _cell_value(content: DjmdContent, column: PrintableField) -> str:
 def print_track_info(
     content_list: Sequence[DjmdContent],
     print_columns: Sequence[PrintableField] | None = None,
+    changed_field: PrintableField | None = None,
+    new_values: Sequence[str] | None = None,
 ):
-    """Print formatted track information"""
+    """Print formatted track information.
+
+    When ``changed_field`` and ``new_values`` are both provided, the matching
+    column renders each row as a before/after preview: the old value is
+    struck through and the new value is appended.
+    """
+    if (changed_field is None) != (new_values is None):
+        raise ValueError(
+            "changed_field and new_values must be provided together"
+        )
+    if new_values is not None and len(new_values) != len(content_list):
+        raise ValueError(
+            f"new_values length ({len(new_values)}) must match content_list length ({len(content_list)})"
+        )
+
     if not content_list:
         return
 
@@ -114,7 +130,14 @@ def print_track_info(
         table.add_column(PRINT_HEADERS[column])
 
     for i, content in enumerate(content_list, 1):
-        table.add_row(str(i), *(_cell_value(content, col) for col in print_columns))
+        cells = []
+        for col in print_columns:
+            old = _cell_value(content, col)
+            if col is changed_field and new_values is not None:
+                cells.append(f"[strike]{old}[/strike] [bold]{new_values[i - 1]}[/bold]")
+            else:
+                cells.append(old)
+        table.add_row(str(i), *cells)
 
     console.print(table)
     logger.debug(console.export_text(clear=True))

--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -1,0 +1,125 @@
+"""Rich-based rendering for rekordbox-edit.
+
+All rich Console output should go through the module-level ``console`` and be
+drained to the debug log immediately after printing:
+
+    console.print(...)
+    logger.debug(console.export_text(clear=True))
+
+Plain text output should continue to use ``logger.info()``.
+"""
+
+import logging
+from enum import Enum
+from typing import Dict, Sequence
+
+from pyrekordbox.db6 import DjmdContent
+from rich.console import Console
+
+from rekordbox_edit.utils import get_file_type_name
+
+logger = logging.getLogger(__name__)
+
+console = Console(record=True)
+
+
+class PrintableField(Enum):
+    """Columns of DjmdContent that you can print"""
+
+    ID = "ID"
+    FileNameL = "FileNameL"
+    FolderPath = "FolderPath"
+    FileType = "FileType"
+    SampleRate = "SampleRate"
+    BitDepth = "BitDepth"
+    BitRate = "BitRate"
+    ArtistName = "ArtistName"
+    AlbumName = "AlbumName"
+    Title = "Title"
+
+
+# Column widths (total ≈ 240 chars with spacing)
+PRINT_WIDTHS: Dict[PrintableField, int] = {
+    PrintableField.ID: 10,
+    PrintableField.FileNameL: 25,
+    PrintableField.Title: 25,
+    PrintableField.ArtistName: 20,
+    PrintableField.AlbumName: 20,
+    PrintableField.FileType: 4,
+    PrintableField.SampleRate: 8,
+    PrintableField.BitRate: 5,
+    PrintableField.BitDepth: 5,
+    PrintableField.FolderPath: 80,
+}
+
+# Print header
+PRINT_HEADERS: Dict[PrintableField, str] = {
+    PrintableField.ID: f"{'ID':<{PRINT_WIDTHS[PrintableField.ID]}}",
+    PrintableField.FileNameL: f"{'File':<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
+    PrintableField.Title: f"{'Title':<{PRINT_WIDTHS[PrintableField.Title]}}",
+    PrintableField.ArtistName: f"{'Artist':<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
+    PrintableField.AlbumName: f"{'Album':<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
+    PrintableField.FileType: f"{'Type':<{PRINT_WIDTHS[PrintableField.FileType]}}",
+    PrintableField.SampleRate: f"{'SampleRt':<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
+    PrintableField.BitRate: f"{'BitRt':<{PRINT_WIDTHS[PrintableField.BitRate]}}",
+    PrintableField.BitDepth: f"{'BitDp':<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
+    PrintableField.FolderPath: f"{'FolderPath':<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
+}
+
+
+def truncate_field(field: PrintableField, value: str | None):
+    if value is None:
+        return ""
+    if len(value) <= PRINT_WIDTHS[field]:
+        return value
+    available = PRINT_WIDTHS[field] - 3  # Reserve 3 chars for "..."
+    start_chars = available // 5 * 2
+    end_chars = available - start_chars
+    return f"{value[:start_chars]}...{value[-end_chars:]}"
+
+
+def print_track_info(
+    content_list: Sequence[DjmdContent],
+    print_columns: Sequence[PrintableField] | None = None,
+):
+    """Print formatted track information"""
+    if not content_list:
+        return
+
+    print_columns = print_columns or [
+        PrintableField.ID,
+        PrintableField.Title,
+        PrintableField.FileType,
+        PrintableField.SampleRate,
+        PrintableField.BitDepth,
+        PrintableField.FolderPath,
+    ]
+
+    # Calculate width for position column: 2 spaces + digits needed for max position
+    pos_width = 2 + len(str(len(content_list)))
+    header = f"{'#':<{pos_width}}" + "  ".join(
+        map(lambda col: PRINT_HEADERS[col], print_columns)
+    )
+    logger.info(header)
+    logger.info("-" * len(header))
+
+    # Print each track
+    for i, content in enumerate(content_list, 1):
+        # Print row
+        rows = {
+            PrintableField.ID: f"{content.ID:<{PRINT_WIDTHS[PrintableField.ID]}}",
+            PrintableField.FileNameL: f"{truncate_field(PrintableField.FileNameL, content.FileNameL):<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
+            PrintableField.Title: f"{truncate_field(PrintableField.Title, content.Title):<{PRINT_WIDTHS[PrintableField.Title]}}",
+            PrintableField.AlbumName: f"{truncate_field(PrintableField.AlbumName, content.AlbumName):<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
+            PrintableField.ArtistName: f"{truncate_field(PrintableField.ArtistName, content.ArtistName):<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
+            PrintableField.FileType: f"{get_file_type_name(content.FileType):<{PRINT_WIDTHS[PrintableField.FileType]}}",
+            PrintableField.SampleRate: f"{content.SampleRate:<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
+            PrintableField.BitRate: f"{content.BitRate:<{PRINT_WIDTHS[PrintableField.BitRate]}}",
+            PrintableField.BitDepth: f"{content.BitDepth:<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
+            PrintableField.FolderPath: f"{truncate_field(PrintableField.FolderPath, content.FolderPath):<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
+        }
+
+        row = f"{i:<{pos_width}}" + "  ".join(map(lambda col: rows[col], print_columns))
+
+        logger.info(row)
+    logger.info("")

--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -14,7 +14,9 @@ from enum import Enum
 from typing import Dict, Sequence
 
 from pyrekordbox.db6 import DjmdContent
+from rich import box
 from rich.console import Console
+from rich.table import Table
 
 from rekordbox_edit.utils import get_file_type_name
 
@@ -52,18 +54,18 @@ PRINT_WIDTHS: Dict[PrintableField, int] = {
     PrintableField.FolderPath: 80,
 }
 
-# Print header
+# Column headers shown in the rendered table
 PRINT_HEADERS: Dict[PrintableField, str] = {
-    PrintableField.ID: f"{'ID':<{PRINT_WIDTHS[PrintableField.ID]}}",
-    PrintableField.FileNameL: f"{'File':<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
-    PrintableField.Title: f"{'Title':<{PRINT_WIDTHS[PrintableField.Title]}}",
-    PrintableField.ArtistName: f"{'Artist':<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
-    PrintableField.AlbumName: f"{'Album':<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
-    PrintableField.FileType: f"{'Type':<{PRINT_WIDTHS[PrintableField.FileType]}}",
-    PrintableField.SampleRate: f"{'SampleRt':<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
-    PrintableField.BitRate: f"{'BitRt':<{PRINT_WIDTHS[PrintableField.BitRate]}}",
-    PrintableField.BitDepth: f"{'BitDp':<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
-    PrintableField.FolderPath: f"{'FolderPath':<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
+    PrintableField.ID: "ID",
+    PrintableField.FileNameL: "File",
+    PrintableField.Title: "Title",
+    PrintableField.ArtistName: "Artist",
+    PrintableField.AlbumName: "Album",
+    PrintableField.FileType: "Type",
+    PrintableField.SampleRate: "SampleRt",
+    PrintableField.BitRate: "BitRt",
+    PrintableField.BitDepth: "BitDp",
+    PrintableField.FolderPath: "FolderPath",
 }
 
 
@@ -76,6 +78,17 @@ def truncate_field(field: PrintableField, value: str | None):
     start_chars = available // 5 * 2
     end_chars = available - start_chars
     return f"{value[:start_chars]}...{value[-end_chars:]}"
+
+
+def _cell_value(content: DjmdContent, column: PrintableField) -> str:
+    """Render a single DjmdContent field as a string for a table cell."""
+    if column is PrintableField.ID:
+        return str(content.ID)
+    if column is PrintableField.FileType:
+        return get_file_type_name(content.FileType)
+    if column in (PrintableField.SampleRate, PrintableField.BitRate, PrintableField.BitDepth):
+        return str(getattr(content, column.value))
+    return truncate_field(column, getattr(content, column.value))
 
 
 def print_track_info(
@@ -95,31 +108,13 @@ def print_track_info(
         PrintableField.FolderPath,
     ]
 
-    # Calculate width for position column: 2 spaces + digits needed for max position
-    pos_width = 2 + len(str(len(content_list)))
-    header = f"{'#':<{pos_width}}" + "  ".join(
-        map(lambda col: PRINT_HEADERS[col], print_columns)
-    )
-    logger.info(header)
-    logger.info("-" * len(header))
+    table = Table(show_header=True, box=box.SIMPLE)
+    table.add_column("#", justify="right")
+    for column in print_columns:
+        table.add_column(PRINT_HEADERS[column])
 
-    # Print each track
     for i, content in enumerate(content_list, 1):
-        # Print row
-        rows = {
-            PrintableField.ID: f"{content.ID:<{PRINT_WIDTHS[PrintableField.ID]}}",
-            PrintableField.FileNameL: f"{truncate_field(PrintableField.FileNameL, content.FileNameL):<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
-            PrintableField.Title: f"{truncate_field(PrintableField.Title, content.Title):<{PRINT_WIDTHS[PrintableField.Title]}}",
-            PrintableField.AlbumName: f"{truncate_field(PrintableField.AlbumName, content.AlbumName):<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
-            PrintableField.ArtistName: f"{truncate_field(PrintableField.ArtistName, content.ArtistName):<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
-            PrintableField.FileType: f"{get_file_type_name(content.FileType):<{PRINT_WIDTHS[PrintableField.FileType]}}",
-            PrintableField.SampleRate: f"{content.SampleRate:<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
-            PrintableField.BitRate: f"{content.BitRate:<{PRINT_WIDTHS[PrintableField.BitRate]}}",
-            PrintableField.BitDepth: f"{content.BitDepth:<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
-            PrintableField.FolderPath: f"{truncate_field(PrintableField.FolderPath, content.FolderPath):<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
-        }
+        table.add_row(str(i), *(_cell_value(content, col) for col in print_columns))
 
-        row = f"{i:<{pos_width}}" + "  ".join(map(lambda col: rows[col], print_columns))
-
-        logger.info(row)
-    logger.info("")
+    console.print(table)
+    logger.debug(console.export_text(clear=True))

--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -10,6 +10,7 @@ Plain text output should continue to use ``logger.info()``.
 """
 
 import logging
+import os
 from enum import Enum
 from typing import Dict, Sequence
 
@@ -40,20 +41,6 @@ class PrintableField(Enum):
     Title = "Title"
 
 
-# Column widths (total ≈ 240 chars with spacing)
-PRINT_WIDTHS: Dict[PrintableField, int] = {
-    PrintableField.ID: 10,
-    PrintableField.FileNameL: 25,
-    PrintableField.Title: 25,
-    PrintableField.ArtistName: 20,
-    PrintableField.AlbumName: 20,
-    PrintableField.FileType: 4,
-    PrintableField.SampleRate: 8,
-    PrintableField.BitRate: 5,
-    PrintableField.BitDepth: 5,
-    PrintableField.FolderPath: 80,
-}
-
 # Column headers shown in the rendered table
 PRINT_HEADERS: Dict[PrintableField, str] = {
     PrintableField.ID: "ID",
@@ -65,19 +52,8 @@ PRINT_HEADERS: Dict[PrintableField, str] = {
     PrintableField.SampleRate: "SampleRt",
     PrintableField.BitRate: "BitRt",
     PrintableField.BitDepth: "BitDp",
-    PrintableField.FolderPath: "FolderPath",
+    PrintableField.FolderPath: "Folder",
 }
-
-
-def truncate_field(field: PrintableField, value: str | None):
-    if value is None:
-        return ""
-    if len(value) <= PRINT_WIDTHS[field]:
-        return value
-    available = PRINT_WIDTHS[field] - 3  # Reserve 3 chars for "..."
-    start_chars = available // 5 * 2
-    end_chars = available - start_chars
-    return f"{value[:start_chars]}...{value[-end_chars:]}"
 
 
 def _cell_value(content: DjmdContent, column: PrintableField) -> str:
@@ -86,9 +62,10 @@ def _cell_value(content: DjmdContent, column: PrintableField) -> str:
         return str(content.ID)
     if column is PrintableField.FileType:
         return get_file_type_name(content.FileType)
-    if column in (PrintableField.SampleRate, PrintableField.BitRate, PrintableField.BitDepth):
-        return str(getattr(content, column.value))
-    return truncate_field(column, getattr(content, column.value))
+    if column is PrintableField.FolderPath:
+        return os.path.dirname(content.FolderPath or "")
+    value = getattr(content, column.value)
+    return "" if value is None else str(value)
 
 
 def print_track_info(
@@ -104,9 +81,7 @@ def print_track_info(
     struck through and the new value is appended.
     """
     if (changed_field is None) != (new_values is None):
-        raise ValueError(
-            "changed_field and new_values must be provided together"
-        )
+        raise ValueError("changed_field and new_values must be provided together")
     if new_values is not None and len(new_values) != len(content_list):
         raise ValueError(
             f"new_values length ({len(new_values)}) must match content_list length ({len(content_list)})"
@@ -122,12 +97,13 @@ def print_track_info(
         PrintableField.SampleRate,
         PrintableField.BitDepth,
         PrintableField.FolderPath,
+        PrintableField.FileNameL,
     ]
 
     table = Table(show_header=True, box=box.SIMPLE)
     table.add_column("#", justify="right")
     for column in print_columns:
-        table.add_column(PRINT_HEADERS[column])
+        table.add_column(PRINT_HEADERS[column], no_wrap=True, overflow="ellipsis")
 
     for i, content in enumerate(content_list, 1):
         cells = []

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -4,11 +4,9 @@ import logging
 import platform
 import shutil
 from enum import Enum
-from typing import Dict, Sequence
 
 import click
 import ffmpeg
-from pyrekordbox.db6 import DjmdContent
 
 logger = logging.getLogger(__name__)
 
@@ -75,108 +73,6 @@ class InputFormats(Enum):
     FLAC = "flac"
     AIFF = "aiff"
     WAV = "wav"
-
-
-class PrintableField(Enum):
-    """Columns of DjmdContent that you can print"""
-
-    ID = "ID"
-    FileNameL = "FileNameL"
-    FolderPath = "FolderPath"
-    FileType = "FileType"
-    SampleRate = "SampleRate"
-    BitDepth = "BitDepth"
-    BitRate = "BitRate"
-    ArtistName = "ArtistName"
-    AlbumName = "AlbumName"
-    Title = "Title"
-
-
-# Column widths (total ≈ 240 chars with spacing)
-PRINT_WIDTHS: Dict[PrintableField, int] = {
-    PrintableField.ID: 10,
-    PrintableField.FileNameL: 25,
-    PrintableField.Title: 25,
-    PrintableField.ArtistName: 20,
-    PrintableField.AlbumName: 20,
-    PrintableField.FileType: 4,
-    PrintableField.SampleRate: 8,
-    PrintableField.BitRate: 5,
-    PrintableField.BitDepth: 5,
-    PrintableField.FolderPath: 80,
-}
-
-# Print header
-PRINT_HEADERS: Dict[PrintableField, str] = {
-    PrintableField.ID: f"{'ID':<{PRINT_WIDTHS[PrintableField.ID]}}",
-    PrintableField.FileNameL: f"{'File':<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
-    PrintableField.Title: f"{'Title':<{PRINT_WIDTHS[PrintableField.Title]}}",
-    PrintableField.ArtistName: f"{'Artist':<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
-    PrintableField.AlbumName: f"{'Album':<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
-    PrintableField.FileType: f"{'Type':<{PRINT_WIDTHS[PrintableField.FileType]}}",
-    PrintableField.SampleRate: f"{'SampleRt':<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
-    PrintableField.BitRate: f"{'BitRt':<{PRINT_WIDTHS[PrintableField.BitRate]}}",
-    PrintableField.BitDepth: f"{'BitDp':<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
-    PrintableField.FolderPath: f"{'FolderPath':<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
-}
-
-
-def truncate_field(field: PrintableField, value: str | None):
-    if value is None:
-        return ""
-    if len(value) <= PRINT_WIDTHS[field]:
-        return value
-    available = PRINT_WIDTHS[field] - 3  # Reserve 3 chars for "..."
-    start_chars = available // 5 * 2
-    end_chars = available - start_chars
-    return f"{value[:start_chars]}...{value[-end_chars:]}"
-
-
-def print_track_info(
-    content_list: Sequence[DjmdContent],
-    print_columns: Sequence[PrintableField] | None = None,
-):
-    """Print formatted track information"""
-    if not content_list:
-        return
-
-    print_columns = print_columns or [
-        PrintableField.ID,
-        PrintableField.Title,
-        PrintableField.FileType,
-        PrintableField.SampleRate,
-        PrintableField.BitDepth,
-        PrintableField.FolderPath,
-    ]
-
-    # Calculate width for position column: 2 spaces + digits needed for max position
-    pos_width = 2 + len(str(len(content_list)))
-    header = f"{'#':<{pos_width}}" + "  ".join(
-        map(lambda col: PRINT_HEADERS[col], print_columns)
-    )
-    logger.info(header)
-    logger.info("-" * len(header))
-
-    # Print each track
-    for i, content in enumerate(content_list, 1):
-        # Print row
-        rows = {
-            PrintableField.ID: f"{content.ID:<{PRINT_WIDTHS[PrintableField.ID]}}",
-            PrintableField.FileNameL: f"{truncate_field(PrintableField.FileNameL, content.FileNameL):<{PRINT_WIDTHS[PrintableField.FileNameL]}}",
-            PrintableField.Title: f"{truncate_field(PrintableField.Title, content.Title):<{PRINT_WIDTHS[PrintableField.Title]}}",
-            PrintableField.AlbumName: f"{truncate_field(PrintableField.AlbumName, content.AlbumName):<{PRINT_WIDTHS[PrintableField.AlbumName]}}",
-            PrintableField.ArtistName: f"{truncate_field(PrintableField.ArtistName, content.ArtistName):<{PRINT_WIDTHS[PrintableField.ArtistName]}}",
-            PrintableField.FileType: f"{get_file_type_name(content.FileType):<{PRINT_WIDTHS[PrintableField.FileType]}}",
-            PrintableField.SampleRate: f"{content.SampleRate:<{PRINT_WIDTHS[PrintableField.SampleRate]}}",
-            PrintableField.BitRate: f"{content.BitRate:<{PRINT_WIDTHS[PrintableField.BitRate]}}",
-            PrintableField.BitDepth: f"{content.BitDepth:<{PRINT_WIDTHS[PrintableField.BitDepth]}}",
-            PrintableField.FolderPath: f"{truncate_field(PrintableField.FolderPath, content.FolderPath):<{PRINT_WIDTHS[PrintableField.FolderPath]}}",
-        }
-
-        row = f"{i:<{pos_width}}" + "  ".join(map(lambda col: rows[col], print_columns))
-
-        logger.info(row)
-    logger.info("")
 
 
 def ffmpeg_in_path():

--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -16,6 +16,7 @@ from rekordbox_edit.commands.convert import (
     rollback_and_cleanup,
     update_database_record,
 )
+from rekordbox_edit.display import PrintableField
 from rekordbox_edit.utils import OutputFormats, UserQuit
 
 
@@ -671,7 +672,11 @@ class TestConvertCommand:
         result = CliRunner().invoke(convert_command, ["--dry-run"])
 
         assert result.exit_code == 0
-        mock_print_track_info.assert_called_once_with([mock_content])
+        mock_print_track_info.assert_called_once_with(
+            [mock_content],
+            changed_field=PrintableField.FileType,
+            new_values=["AIFF"],
+        )
         mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.commands.convert.get_rekordbox_pid")
@@ -804,7 +809,11 @@ class TestConvertCommand:
         result = runner.invoke(convert_command, ["--dry-run"])
 
         assert result.exit_code == 0
-        mock_print_track_info.assert_called_once_with([mock_flac_content])
+        mock_print_track_info.assert_called_once_with(
+            [mock_flac_content],
+            changed_field=PrintableField.FileType,
+            new_values=["AIFF"],
+        )
 
     @patch("rekordbox_edit.commands.convert.get_rekordbox_pid")
     @patch("rekordbox_edit.commands.convert.get_filtered_content")
@@ -1570,7 +1579,11 @@ class TestConvertCommandErrorPaths:
         result = CliRunner().invoke(convert_command, ["--yes", "--dry-run"])
 
         assert result.exit_code == 0
-        mock_print_track_info.assert_called_once_with([content2])
+        mock_print_track_info.assert_called_once_with(
+            [content2],
+            changed_field=PrintableField.FileType,
+            new_values=["AIFF"],
+        )
 
     @patch("rekordbox_edit.commands.convert.print_track_info")
     @patch("rekordbox_edit.commands.convert.get_rekordbox_pid")
@@ -1613,7 +1626,11 @@ class TestConvertCommandErrorPaths:
 
         assert result.exit_code == 0
         mock_logger.warning.assert_called()
-        mock_print_track_info.assert_called_once_with([content2])
+        mock_print_track_info.assert_called_once_with(
+            [content2],
+            changed_field=PrintableField.FileType,
+            new_values=["AIFF"],
+        )
 
     @patch("rekordbox_edit.commands.convert.sys")
     @patch("rekordbox_edit.commands.convert.confirm")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,17 +1,12 @@
 """Unit tests for the display module."""
 
-from typing import Callable
-
 import pytest
-from pyrekordbox.db6 import DjmdContent
 from rich.console import Console
 
 from rekordbox_edit import display
 from rekordbox_edit.display import (
-    PRINT_WIDTHS,
     PrintableField,
     print_track_info,
-    truncate_field,
 )
 from rekordbox_edit.utils import get_file_type_name
 
@@ -24,50 +19,6 @@ def wide_console(monkeypatch):
     (e.g. FolderPath) with an ellipsis and makes substring assertions flaky.
     """
     monkeypatch.setattr(display, "console", Console(record=True, width=400))
-
-
-class TestTruncateField:
-    """Test truncate_field function."""
-
-    def test_truncate_field_none_value(self):
-        """Test truncate_field returns empty string for None value."""
-        result = truncate_field(PrintableField.Title, None)
-        assert result == ""
-
-    def test_truncate_field_empty_string(self):
-        """Test truncate_field with empty string."""
-        result = truncate_field(PrintableField.Title, "")
-        assert result == ""
-
-    def test_truncate_field_short_value(self):
-        """Test truncate_field returns value as-is when it fits."""
-        short_title = "Short Title"
-        result = truncate_field(PrintableField.Title, short_title)
-        assert result == short_title
-
-    def test_truncate_field_exact_width(self):
-        """Test truncate_field with value exactly at width limit."""
-        # Create a value exactly the width of Title field (25 chars)
-        exact_width_title = "X" * PRINT_WIDTHS[PrintableField.Title]
-        result = truncate_field(PrintableField.Title, exact_width_title)
-        assert result == exact_width_title
-
-    def test_truncate_field_long_value(self):
-        """Test truncate_field truncates long values with ellipsis."""
-        long_title = "This is a very long title that exceeds the width limit"
-        result = truncate_field(PrintableField.Title, long_title)
-
-        assert "..." in result
-        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
-
-    def test_truncate_field_minimal_truncation(self):
-        """Test truncate_field with value just over the limit."""
-        # Create a value just 1 char over the limit
-        over_limit_title = "X" * (PRINT_WIDTHS[PrintableField.Title] + 1)
-        result = truncate_field(PrintableField.Title, over_limit_title)
-
-        assert "..." in result
-        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
 
 
 class TestPrintTrackInfo:
@@ -97,27 +48,24 @@ class TestPrintTrackInfo:
         self,
         capsys,
         wide_console,
-        make_djmd_content_item: Callable[[], DjmdContent],
+        make_djmd_content_item,
     ):
-        """Test printing a single track with the default print_columns.
-
-        Default columns are: ID, Title, FileType, SampleRate, BitDepth, FolderPath
-        (ArtistName and AlbumName are NOT included by default)
-        """
-        # Setup mock content
-        mock_content = make_djmd_content_item()
+        """Default columns include ID, Title, FileType, SampleRate, BitDepth, FileNameL, FolderPath."""
+        mock_content = make_djmd_content_item(
+            FileNameL="my-song.flac",
+            FolderPath="/music/library/my-song.flac",
+        )
 
         print_track_info([mock_content])
 
         captured = capsys.readouterr()
-        # Check default columns are present
         assert mock_content.Title in captured.out
         assert get_file_type_name(mock_content.FileType) in captured.out
         assert str(mock_content.SampleRate) in captured.out
         assert str(mock_content.BitDepth) in captured.out
-        # FolderPath should be in output (may or may not be truncated depending on length)
-        # The default test path is 66 chars, column width is 80, so no truncation
-        assert "test_track.wav" in captured.out
+        assert "my-song.flac" in captured.out
+        # FolderPath renders the directory portion, not the full path
+        assert "/music/library" in captured.out
 
     def test_track_with_zero_values(self, capsys, wide_console, make_djmd_content_item):
         """Test printing track with zero values."""

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2,8 +2,11 @@
 
 from typing import Callable
 
+import pytest
 from pyrekordbox.db6 import DjmdContent
+from rich.console import Console
 
+from rekordbox_edit import display
 from rekordbox_edit.display import (
     PRINT_WIDTHS,
     PrintableField,
@@ -11,6 +14,16 @@ from rekordbox_edit.display import (
     truncate_field,
 )
 from rekordbox_edit.utils import get_file_type_name
+
+
+@pytest.fixture
+def wide_console(monkeypatch):
+    """Swap the module console for one wide enough to render without truncation.
+
+    Rich's default non-TTY width is 80 cols, which truncates long values
+    (e.g. FolderPath) with an ellipsis and makes substring assertions flaky.
+    """
+    monkeypatch.setattr(display, "console", Console(record=True, width=400))
 
 
 class TestTruncateField:
@@ -81,7 +94,10 @@ class TestPrintTrackInfo:
         assert captured.out == ""
 
     def test_default_columns(
-        self, capsys, make_djmd_content_item: Callable[[], DjmdContent]
+        self,
+        capsys,
+        wide_console,
+        make_djmd_content_item: Callable[[], DjmdContent],
     ):
         """Test printing a single track with the default print_columns.
 
@@ -103,7 +119,7 @@ class TestPrintTrackInfo:
         # The default test path is 66 chars, column width is 80, so no truncation
         assert "test_track.wav" in captured.out
 
-    def test_track_with_zero_values(self, capsys, make_djmd_content_item):
+    def test_track_with_zero_values(self, capsys, wide_console, make_djmd_content_item):
         """Test printing track with zero values."""
         # Setup mock content with zero values
         mock_content = make_djmd_content_item(
@@ -120,7 +136,7 @@ class TestPrintTrackInfo:
         data_line = [line for line in lines if "test" in line][0]
         assert data_line.count("0") == 3
 
-    def test_multiple_tracks(self, capsys, make_djmd_content_item):
+    def test_multiple_tracks(self, capsys, wide_console, make_djmd_content_item):
         """Test printing multiple tracks."""
         mock_content1 = make_djmd_content_item(
             ID=123,

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,145 @@
+"""Unit tests for the display module."""
+
+from typing import Callable
+
+from pyrekordbox.db6 import DjmdContent
+
+from rekordbox_edit.display import (
+    PRINT_WIDTHS,
+    PrintableField,
+    print_track_info,
+    truncate_field,
+)
+from rekordbox_edit.utils import get_file_type_name
+
+
+class TestTruncateField:
+    """Test truncate_field function."""
+
+    def test_truncate_field_none_value(self):
+        """Test truncate_field returns empty string for None value."""
+        result = truncate_field(PrintableField.Title, None)
+        assert result == ""
+
+    def test_truncate_field_empty_string(self):
+        """Test truncate_field with empty string."""
+        result = truncate_field(PrintableField.Title, "")
+        assert result == ""
+
+    def test_truncate_field_short_value(self):
+        """Test truncate_field returns value as-is when it fits."""
+        short_title = "Short Title"
+        result = truncate_field(PrintableField.Title, short_title)
+        assert result == short_title
+
+    def test_truncate_field_exact_width(self):
+        """Test truncate_field with value exactly at width limit."""
+        # Create a value exactly the width of Title field (25 chars)
+        exact_width_title = "X" * PRINT_WIDTHS[PrintableField.Title]
+        result = truncate_field(PrintableField.Title, exact_width_title)
+        assert result == exact_width_title
+
+    def test_truncate_field_long_value(self):
+        """Test truncate_field truncates long values with ellipsis."""
+        long_title = "This is a very long title that exceeds the width limit"
+        result = truncate_field(PrintableField.Title, long_title)
+
+        assert "..." in result
+        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
+
+    def test_truncate_field_minimal_truncation(self):
+        """Test truncate_field with value just over the limit."""
+        # Create a value just 1 char over the limit
+        over_limit_title = "X" * (PRINT_WIDTHS[PrintableField.Title] + 1)
+        result = truncate_field(PrintableField.Title, over_limit_title)
+
+        assert "..." in result
+        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
+
+
+class TestPrintTrackInfo:
+    """Test print_track_info function."""
+
+    TEST_PRINT_COLUMNS = [
+        PrintableField.ID,
+        PrintableField.FileNameL,
+        PrintableField.Title,
+        PrintableField.ArtistName,
+        PrintableField.AlbumName,
+        PrintableField.FileType,
+        PrintableField.SampleRate,
+        PrintableField.BitDepth,
+        PrintableField.BitRate,
+        PrintableField.FolderPath,
+    ]
+
+    def test_empty_content_list(self, capsys):
+        """Test printing with empty content list."""
+        print_track_info([])
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_default_columns(
+        self, capsys, make_djmd_content_item: Callable[[], DjmdContent]
+    ):
+        """Test printing a single track with the default print_columns.
+
+        Default columns are: ID, Title, FileType, SampleRate, BitDepth, FolderPath
+        (ArtistName and AlbumName are NOT included by default)
+        """
+        # Setup mock content
+        mock_content = make_djmd_content_item()
+
+        print_track_info([mock_content])
+
+        captured = capsys.readouterr()
+        # Check default columns are present
+        assert mock_content.Title in captured.out
+        assert get_file_type_name(mock_content.FileType) in captured.out
+        assert str(mock_content.SampleRate) in captured.out
+        assert str(mock_content.BitDepth) in captured.out
+        # FolderPath should be in output (may or may not be truncated depending on length)
+        # The default test path is 66 chars, column width is 80, so no truncation
+        assert "test_track.wav" in captured.out
+
+    def test_track_with_zero_values(self, capsys, make_djmd_content_item):
+        """Test printing track with zero values."""
+        # Setup mock content with zero values
+        mock_content = make_djmd_content_item(
+            ID=123,
+            SampleRate=0,
+            BitRate=0,
+            BitDepth=0,
+        )
+
+        print_track_info([mock_content], self.TEST_PRINT_COLUMNS)
+
+        captured = capsys.readouterr()
+        lines = captured.out.split("\n")
+        data_line = [line for line in lines if "test" in line][0]
+        assert data_line.count("0") == 3
+
+    def test_multiple_tracks(self, capsys, make_djmd_content_item):
+        """Test printing multiple tracks."""
+        mock_content1 = make_djmd_content_item(
+            ID=123,
+            FileNameL="track1.flac",
+            FileType=5,
+            FolderPath="/path/track1.flac",
+        )
+
+        mock_content2 = make_djmd_content_item(
+            ID=456,
+            FileNameL="track2.mp3",
+            FileType=1,
+            FolderPath="/path/track2.mp3",
+        )
+
+        print_track_info([mock_content1, mock_content2])
+
+        captured = capsys.readouterr()
+        assert "track1.flac" in captured.out
+        assert "track2.mp3" in captured.out
+        assert "FLAC" in captured.out
+        assert "MP3" in captured.out

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -136,6 +136,46 @@ class TestPrintTrackInfo:
         data_line = [line for line in lines if "test" in line][0]
         assert data_line.count("0") == 3
 
+    def test_change_preview_renders_old_struck_through_with_new(
+        self, capsys, wide_console, make_djmd_content_item
+    ):
+        """When changed_field + new_values are provided, both old and new appear in the cell."""
+        mock_content = make_djmd_content_item(Title="Old Name")
+
+        print_track_info(
+            [mock_content],
+            print_columns=[PrintableField.Title],
+            changed_field=PrintableField.Title,
+            new_values=["New Name"],
+        )
+
+        captured = capsys.readouterr()
+        assert "Old Name" in captured.out
+        assert "New Name" in captured.out
+
+    def test_change_preview_requires_both_args(self, make_djmd_content_item):
+        """Providing only one of changed_field/new_values raises ValueError."""
+        mock_content = make_djmd_content_item()
+
+        with pytest.raises(ValueError, match="must be provided together"):
+            print_track_info(
+                [mock_content], changed_field=PrintableField.Title
+            )
+
+        with pytest.raises(ValueError, match="must be provided together"):
+            print_track_info([mock_content], new_values=["x"])
+
+    def test_change_preview_length_mismatch_raises(self, make_djmd_content_item):
+        """new_values length must match content_list length."""
+        mock_content = make_djmd_content_item()
+
+        with pytest.raises(ValueError, match="length"):
+            print_track_info(
+                [mock_content],
+                changed_field=PrintableField.Title,
+                new_values=["a", "b"],
+            )
+
     def test_multiple_tracks(self, capsys, wide_console, make_djmd_content_item):
         """Test printing multiple tracks."""
         mock_content1 = make_djmd_content_item(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,15 @@
 """Unit tests for utils module functionality."""
 
-from typing import Callable
 from unittest.mock import patch
 
 import pytest
-from pyrekordbox.db6 import DjmdContent
 
 from rekordbox_edit.utils import (
-    PRINT_WIDTHS,
-    PrintableField,
     UserQuit,
     get_audio_info,
     get_extension_for_format,
     get_file_type_for_format,
     get_file_type_name,
-    print_track_info,
 )
 
 
@@ -94,158 +89,6 @@ class TestGetGetExtensionForFormat:
 
         with pytest.raises(ValueError, match="Format name cannot be empty or None"):
             get_extension_for_format(None)  # ty: ignore[invalid-argument-type]
-
-
-class TestTruncateField:
-    """Test truncate_field function."""
-
-    def test_truncate_field_none_value(self):
-        """Test truncate_field returns empty string for None value."""
-        from rekordbox_edit.utils import PrintableField, truncate_field
-
-        result = truncate_field(PrintableField.Title, None)
-        assert result == ""
-
-    def test_truncate_field_empty_string(self):
-        """Test truncate_field with empty string."""
-        from rekordbox_edit.utils import PrintableField, truncate_field
-
-        result = truncate_field(PrintableField.Title, "")
-        assert result == ""
-
-    def test_truncate_field_short_value(self):
-        """Test truncate_field returns value as-is when it fits."""
-        from rekordbox_edit.utils import PrintableField, truncate_field
-
-        short_title = "Short Title"
-        result = truncate_field(PrintableField.Title, short_title)
-        assert result == short_title
-
-    def test_truncate_field_exact_width(self):
-        """Test truncate_field with value exactly at width limit."""
-        from rekordbox_edit.utils import (
-            PRINT_WIDTHS,
-            PrintableField,
-            truncate_field,
-        )
-
-        # Create a value exactly the width of Title field (25 chars)
-        exact_width_title = "X" * PRINT_WIDTHS[PrintableField.Title]
-        result = truncate_field(PrintableField.Title, exact_width_title)
-        assert result == exact_width_title
-
-    def test_truncate_field_long_value(self):
-        """Test truncate_field truncates long values with ellipsis."""
-        from rekordbox_edit.utils import PrintableField, truncate_field
-
-        long_title = "This is a very long title that exceeds the width limit"
-        result = truncate_field(PrintableField.Title, long_title)
-
-        assert "..." in result
-        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
-
-    def test_truncate_field_minimal_truncation(self):
-        """Test truncate_field with value just over the limit."""
-        from rekordbox_edit.utils import (
-            PRINT_WIDTHS,
-            PrintableField,
-            truncate_field,
-        )
-
-        # Create a value just 1 char over the limit
-        over_limit_title = "X" * (PRINT_WIDTHS[PrintableField.Title] + 1)
-        result = truncate_field(PrintableField.Title, over_limit_title)
-
-        assert "..." in result
-        assert len(result) == PRINT_WIDTHS[PrintableField.Title]
-
-
-class TestPrintTrackInfo:
-    """Test print_track_info function."""
-
-    TEST_PRINT_COLUMNS = [
-        PrintableField.ID,
-        PrintableField.FileNameL,
-        PrintableField.Title,
-        PrintableField.ArtistName,
-        PrintableField.AlbumName,
-        PrintableField.FileType,
-        PrintableField.SampleRate,
-        PrintableField.BitDepth,
-        PrintableField.BitRate,
-        PrintableField.FolderPath,
-    ]
-
-    def test_empty_content_list(self, capsys):
-        """Test printing with empty content list."""
-        print_track_info([])
-
-        captured = capsys.readouterr()
-        assert captured.out == ""
-
-    def test_default_columns(
-        self, capsys, make_djmd_content_item: Callable[[], DjmdContent]
-    ):
-        """Test printing a single track with the default print_columns.
-
-        Default columns are: ID, Title, FileType, SampleRate, BitDepth, FolderPath
-        (ArtistName and AlbumName are NOT included by default)
-        """
-        # Setup mock content
-        mock_content = make_djmd_content_item()
-
-        print_track_info([mock_content])
-
-        captured = capsys.readouterr()
-        # Check default columns are present
-        assert mock_content.Title in captured.out
-        assert get_file_type_name(mock_content.FileType) in captured.out
-        assert str(mock_content.SampleRate) in captured.out
-        assert str(mock_content.BitDepth) in captured.out
-        # FolderPath should be in output (may or may not be truncated depending on length)
-        # The default test path is 66 chars, column width is 80, so no truncation
-        assert "test_track.wav" in captured.out
-
-    def test_track_with_zero_values(self, capsys, make_djmd_content_item):
-        """Test printing track with zero values."""
-        # Setup mock content with zero values
-        mock_content = make_djmd_content_item(
-            ID=123,
-            SampleRate=0,
-            BitRate=0,
-            BitDepth=0,
-        )
-
-        print_track_info([mock_content], self.TEST_PRINT_COLUMNS)
-
-        captured = capsys.readouterr()
-        lines = captured.out.split("\n")
-        data_line = [line for line in lines if "test" in line][0]
-        assert data_line.count("0") == 3
-
-    def test_multiple_tracks(self, capsys, make_djmd_content_item):
-        """Test printing multiple tracks."""
-        mock_content1 = make_djmd_content_item(
-            ID=123,
-            FileNameL="track1.flac",
-            FileType=5,
-            FolderPath="/path/track1.flac",
-        )
-
-        mock_content2 = make_djmd_content_item(
-            ID=456,
-            FileNameL="track2.mp3",
-            FileType=1,
-            FolderPath="/path/track2.mp3",
-        )
-
-        print_track_info([mock_content1, mock_content2])
-
-        captured = capsys.readouterr()
-        assert "track1.flac" in captured.out
-        assert "track2.mp3" in captured.out
-        assert "FLAC" in captured.out
-        assert "MP3" in captured.out
 
 
 class TestGetAudioInfo:

--- a/uv.lock
+++ b/uv.lock
@@ -473,6 +473,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -555,6 +567,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -992,6 +1013,7 @@ dependencies = [
     { name = "ffmpeg-python" },
     { name = "platformdirs" },
     { name = "pyrekordbox" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -1013,6 +1035,7 @@ requires-dist = [
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "platformdirs", specifier = ">=4.3.8,<5.0.0" },
     { name = "pyrekordbox", specifier = "==0.4.4" },
+    { name = "rich", specifier = ">=13.0.0,<15.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1026,6 +1049,19 @@ dev = [
     { name = "pytest-watcher", specifier = ">=0.6.3,<1" },
     { name = "ruff", specifier = ">=0.12.8,<1" },
     { name = "ty", specifier = ">=0.0.1,<1" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add rich dependency and move PrintableField, PRINT_WIDTHS, PRINT_HEADERS, truncate_field, and print_track_info from utils to a new display module with a module-level Console for upcoming rich-based rendering. Update edit, convert, and search command imports.