### PR TITLE
fix(display): Don't crash on unknown file type during print_track_info

### DIFF
--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -61,7 +61,13 @@ def _cell_value(content: DjmdContent, column: PrintableField) -> str:
     if column is PrintableField.ID:
         return str(content.ID)
     if column is PrintableField.FileType:
-        return get_file_type_name(content.FileType)
+        try:
+            return get_file_type_name(content.FileType)
+        except ValueError:
+            logger.warning(
+                f"Unexpected FileType [{content.FileType}] for track ID [{content.ID}]"
+            )
+            return "UNKNOWN"
     if column is PrintableField.FolderPath:
         return os.path.dirname(content.FolderPath or "")
     value = getattr(content, column.value)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -106,9 +106,7 @@ class TestPrintTrackInfo:
         mock_content = make_djmd_content_item()
 
         with pytest.raises(ValueError, match="must be provided together"):
-            print_track_info(
-                [mock_content], changed_field=PrintableField.Title
-            )
+            print_track_info([mock_content], changed_field=PrintableField.Title)
 
         with pytest.raises(ValueError, match="must be provided together"):
             print_track_info([mock_content], new_values=["x"])
@@ -147,3 +145,18 @@ class TestPrintTrackInfo:
         assert "track2.mp3" in captured.out
         assert "FLAC" in captured.out
         assert "MP3" in captured.out
+
+    def test_track_with_unknown_file_type(
+        self, capsys, wide_console, make_djmd_content_item
+    ):
+        """Test printing track with unknown file type."""
+        # Setup mock content with zero values
+        mock_content = make_djmd_content_item(
+            ID=123,
+            FileType=6,
+        )
+
+        print_track_info([mock_content], self.TEST_PRINT_COLUMNS)
+
+        captured = capsys.readouterr()
+        assert "UNKNOWN" in captured.out


### PR DESCRIPTION
Whaddya know there's more possible file types that what `pyrekordbox` documents!