### PR TITLE
fix: handle stdin BOM character on windows

### DIFF
--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -15,12 +15,16 @@ logger = logging.getLogger(__name__)
 
 
 def _handle_stdin(args) -> bool:
-    """Append track IDs from piped stdin to args.track_ids. Returns True if stdin was piped."""
+    """Append track IDs from piped stdin to args.track_ids. Returns True if IDs were piped."""
     if sys.stdin.isatty():
         return False
-    stdin_data = sys.stdin.read().strip()
-    if stdin_data:
-        args.track_ids = list(args.track_ids) + stdin_data.split()
+    # PowerShell pipes data as UTF-8-with-BOM, but Python decodes stdin with the
+    # locale codepage (e.g. cp1252 on Windows), which would leave BOM bytes glued to
+    # the first track ID. Read raw bytes and decode as UTF-8, dropping any BOM.
+    tokens = sys.stdin.buffer.read().decode("utf-8-sig", errors="replace").split()
+    if not tokens:
+        return False
+    args.track_ids = list(args.track_ids) + tokens
     return True
 
 
@@ -68,7 +72,9 @@ def _interactive_filter_edits(plan: EditPlan) -> EditPlan:
     return EditPlan(field=plan.field, edits=confirmed)
 
 
-def _confirm_converts(plan: ConvertPlan, args: ConvertCommandArgs) -> ConvertPlan | None:
+def _confirm_converts(
+    plan: ConvertPlan, args: ConvertCommandArgs
+) -> ConvertPlan | None:
     """Gate the convert plan through user confirmation. Returns None if cancelled."""
     if args.yes:
         return plan
@@ -76,7 +82,8 @@ def _confirm_converts(plan: ConvertPlan, args: ConvertCommandArgs) -> ConvertPla
         return _interactive_filter_converts(plan)
     try:
         if not confirm(
-            f"Convert {len(plan.files)} files to {plan.format_out.upper()}?", default=True
+            f"Convert {len(plan.files)} files to {plan.format_out.upper()}?",
+            default=True,
         ):
             logger.info("Cancelled.")
             return None

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -44,18 +44,36 @@ class TestHandleStdin:
         args = Mock(track_ids=["existing"])
         with patch("sys.stdin") as mock_stdin:
             mock_stdin.isatty.return_value = False
-            mock_stdin.read.return_value = "AAA BBB"
+            mock_stdin.buffer.read.return_value = b"AAA BBB"
             result = _handle_stdin(args)
         assert result is True
         assert args.track_ids == ["existing", "AAA", "BBB"]
 
-    def test_empty_piped_stdin_returns_true_without_modifying(self):
+    def test_strips_bom_from_piped_stdin(self):
         args = Mock(track_ids=[])
         with patch("sys.stdin") as mock_stdin:
             mock_stdin.isatty.return_value = False
-            mock_stdin.read.return_value = "  "
+            mock_stdin.buffer.read.return_value = bytes([0xEF, 0xBB, 0xBF]) + b"AAA BBB"
             result = _handle_stdin(args)
         assert result is True
+        assert args.track_ids == ["AAA", "BBB"]
+
+    def test_empty_piped_stdin_returns_false(self):
+        args = Mock(track_ids=[])
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.buffer.read.return_value = b"  "
+            result = _handle_stdin(args)
+        assert result is False
+        assert args.track_ids == []
+
+    def test_bom_only_piped_stdin_returns_false(self):
+        args = Mock(track_ids=[])
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.buffer.read.return_value = bytes([0xEF, 0xBB, 0xBF])
+            result = _handle_stdin(args)
+        assert result is False
         assert args.track_ids == []
 
 


### PR DESCRIPTION
attempting to pipe one command into another in powershell resulted in the first ID getting swallowed due to a BOM character at the start.