### PR TITLE
feat!: refactor API design to be one per command

### DIFF
--- a/rekordbox_edit/__init__.py
+++ b/rekordbox_edit/__init__.py
@@ -4,6 +4,6 @@ __version__ = "0.1.0"
 __author__ = "James Viall"
 __email__ = "jamesviall@pm.me"
 
-from rekordbox_edit.api import convert, edit, plan_convert, plan_edit, search
+from rekordbox_edit.api import convert, edit, search
 
-__all__ = ["search", "plan_edit", "edit", "plan_convert", "convert"]
+__all__ = ["search", "edit", "convert"]

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -8,6 +8,7 @@ class PrintChoice(Enum):
     IDS = 1
     INFO = 2
     DEBUG = 3
+    JSON = 4
 
 
 print_option = click.option(
@@ -15,7 +16,7 @@ print_option = click.option(
     "print_opt",  # avoid shadowing the print() function
     default="info",
     type=click.Choice(PrintChoice, case_sensitive=False),
-    help="Configures the kind of console output you want from the command, if any. The 'ids' option can be used to pipe a list of resulting content IDs into to another command.",
+    help="Configures the kind of console output you want from the command, if any. Use 'ids' to pipe a list of resulting content IDs or 'json' to pipe full track records into another command.",
 )
 
 track_ids_argument = click.argument("track-ids", type=str, required=False, nargs=-1)

--- a/rekordbox_edit/api/__init__.py
+++ b/rekordbox_edit/api/__init__.py
@@ -1,11 +1,11 @@
 """Public API for rekordbox-edit.
 
 Usage:
-    from rekordbox_edit.api import search, plan_edit, edit, plan_convert, convert
+    from rekordbox_edit.api import search, edit, convert
 """
 
-from rekordbox_edit.api.convert import convert, plan_convert
-from rekordbox_edit.api.edit import edit, plan_edit
+from rekordbox_edit.api.convert import convert
+from rekordbox_edit.api.edit import edit
 from rekordbox_edit.api.search import search
 
-__all__ = ["search", "plan_edit", "edit", "plan_convert", "convert"]
+__all__ = ["search", "edit", "convert"]

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
+
 from pyrekordbox.db6 import DjmdContent
 
-from rekordbox_edit.models import Track
+from rekordbox_edit.models import ConvertOp, EditOp, Track
 
 _COLUMN_KEYS = tuple(c.key for c in DjmdContent.__table__.columns)
 
@@ -12,3 +14,18 @@ def _track_from_content(content: DjmdContent) -> Track:
     data["ArtistName"] = content.ArtistName
     data["AlbumName"] = content.AlbumName
     return Track(**data)
+
+
+def _order_tracks_by_op(
+    contents: Sequence[DjmdContent], ops: Sequence[EditOp | ConvertOp]
+) -> list[Track]:
+    """Build Track list in op order from raw DjmdContent rows.
+
+    Builds the id -> content lookup internally so callers don't have to. Ops
+    whose id is not in `contents` are silently skipped (the caller already
+    knows about the divergence from upstream logic).
+    """
+    content_map = {str(c.ID): c for c in contents}
+    return [
+        _track_from_content(content_map[op.id]) for op in ops if op.id in content_map
+    ]

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -2,17 +2,13 @@ from pyrekordbox.db6 import DjmdContent
 
 from rekordbox_edit.models import Track
 
+_COLUMN_KEYS = tuple(c.key for c in DjmdContent.__table__.columns)
+
 
 def _track_from_content(content: DjmdContent) -> Track:
-    return Track(
-        ID=str(content.ID),
-        Title=content.Title,
-        ArtistName=content.ArtistName,
-        AlbumName=content.AlbumName,
-        FileNameL=content.FileNameL,
-        FolderPath=content.FolderPath,
-        FileType=content.FileType,
-        SampleRate=content.SampleRate,
-        BitDepth=content.BitDepth,
-        BitRate=content.BitRate,
-    )
+    data = {k: getattr(content, k) for k in _COLUMN_KEYS}
+    data["ID"] = str(data["ID"])
+    # association_proxy attributes; not present in __table__.columns
+    data["ArtistName"] = content.ArtistName
+    data["AlbumName"] = content.AlbumName
+    return Track(**data)

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # ── ffmpeg helpers ────────────────────────────────────────────────────────
 
 
-def convert_to_lossless(input_path, output_path, output_format):
+def _convert_to_lossless(input_path, output_path, output_format):
     """Convert lossless file to another lossless format, preserving bit depth."""
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
@@ -87,7 +87,7 @@ def convert_to_lossless(input_path, output_path, output_format):
         raise e
 
 
-def convert_to_mp3(input_path, mp3_path):
+def _convert_to_mp3(input_path, mp3_path):
     """Convert lossless file to MP3 320kbps CBR."""
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
@@ -120,7 +120,7 @@ def convert_to_mp3(input_path, mp3_path):
         raise e
 
 
-def update_database_record(
+def _update_database_record(
     db, content_id, new_filename, new_folder, output_format
 ) -> None:
     """Update database record with new file information."""
@@ -164,7 +164,7 @@ def update_database_record(
         content.BitRate = converted_bitrate
 
 
-def cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
+def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
     """Clean up converted output files on error or rollback."""
     logger.debug("Cleaning up converted files due to aborted conversion.")
     for op in converted_ops:
@@ -175,7 +175,7 @@ def cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
             pass
 
 
-def rollback_and_cleanup(db, converted_ops: list[ConvertOp]) -> None:
+def _rollback_and_cleanup(db, converted_ops: list[ConvertOp]) -> None:
     """Roll back the database session and clean up any converted files."""
     logger.debug("Attempting DB session rollback.")
     rollback_error = None
@@ -189,12 +189,12 @@ def rollback_and_cleanup(db, converted_ops: list[ConvertOp]) -> None:
             )
             rollback_error = e
     if converted_ops:
-        cleanup_converted_files(converted_ops)
+        _cleanup_converted_files(converted_ops)
     if rollback_error:
         raise rollback_error
 
 
-def get_output_path(content, output_format) -> Tuple[str, str, str]:
+def _get_output_path(content, output_format) -> Tuple[str, str, str]:
     """Calculate output path for a content item."""
     src_folder_path = os.path.normpath(content.FolderPath or "")
     src_file_name = content.FileNameL or ""
@@ -221,7 +221,7 @@ def _classify_convert(content, args: ConvertArgs) -> ConvertOp | SkippedTrack:
             f"file_type={content.FileType} target={target}"
         )
         return SkippedTrack(id=str(content.ID), reason="already_target_format")
-    output_path, _, _ = get_output_path(content, args.format_out)
+    output_path, _, _ = _get_output_path(content, args.format_out)
     if not args.overwrite and os.path.exists(output_path):
         logger.debug(
             f"skip convert id={content.ID} reason=output_file_exists path={output_path}"
@@ -321,9 +321,9 @@ def convert(
                 raise RuntimeError(f"Source not found: {src}")
 
             if args.format_out.upper() == "MP3":
-                success = convert_to_mp3(src, op.output_path)
+                success = _convert_to_mp3(src, op.output_path)
             else:
-                success = convert_to_lossless(
+                success = _convert_to_lossless(
                     src, op.output_path, OutputFormats(args.format_out.lower())
                 )
 
@@ -332,7 +332,7 @@ def convert(
             if not os.path.exists(op.output_path):
                 raise RuntimeError(f"Output file not created: {op.output_path}")
 
-            update_database_record(
+            _update_database_record(
                 db,
                 op.id,
                 os.path.basename(op.output_path),
@@ -352,7 +352,7 @@ def convert(
         logger.debug(
             f"convert rolling back after {len(converted_ops)} partial conversion(s)"
         )
-        rollback_and_cleanup(db, converted_ops)
+        _rollback_and_cleanup(db, converted_ops)
         raise
 
     deleted = 0

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -379,8 +379,13 @@ def convert(
         )
         tracks = _order_tracks_by_op(post_contents, converted_ops)
     except Exception as e:
-        logger.warning(f"Failed to re-query tracks after commit: {e}")
-        tracks = []
+        # Fall back to pre-mutation snapshots so the response stays valid;
+        # the commit succeeded, the caller should not see an alignment error.
+        logger.warning(
+            f"Failed to re-query tracks after commit; falling back to "
+            f"pre-mutation snapshots: {e}"
+        )
+        tracks = _order_tracks_by_op(list(content_map.values()), converted_ops)
 
     return ConvertResponse(
         tracks=tracks,

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -8,13 +8,18 @@ from typing import Tuple
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
-from pydantic import BaseModel
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
 from sqlalchemy import select
 
-from rekordbox_edit.api._utils import _track_from_content
-from rekordbox_edit.models import ConvertPlanArgs, Track
+from rekordbox_edit.api._utils import _order_tracks_by_op
+from rekordbox_edit.models import (
+    ConvertArgs,
+    ConvertOp,
+    ConvertResponse,
+    ConvertResult,
+    SkippedTrack,
+)
 from rekordbox_edit.query import get_filtered_content
 from rekordbox_edit.utils import (
     OutputFormats,
@@ -26,7 +31,7 @@ from rekordbox_edit.utils import (
 logger = logging.getLogger(__name__)
 
 
-# ── Helpers  ──────────────────────────────────────────────────────────────
+# ── ffmpeg helpers ────────────────────────────────────────────────────────
 
 
 def convert_to_lossless(input_path, output_path, output_format):
@@ -62,12 +67,10 @@ def convert_to_lossless(input_path, output_path, output_format):
 
     logger.debug(f"Selected codec: {codec} (bit_depth={bit_depth})")
 
-    output_options = {"acodec": codec, "map_metadata": 0, "write_id3v2": 1}
-
     try:
         (
             ffmpeg.input(input_path)
-            .output(output_path, **output_options)
+            .output(output_path, acodec=codec, map_metadata=0, write_id3v2=1)
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
@@ -92,24 +95,18 @@ def convert_to_mp3(input_path, mp3_path):
         raise Exception(f"FFmpeg not found in PATH.{get_ffmpeg_directions()}")
 
     try:
-        acodec = "libmp3lame"
-        audio_bitrate = "320k"
-        map_metadata = 0
-        write_id3v2 = 1
-
         (
             ffmpeg.input(input_path)
             .output(
                 mp3_path,
-                acodec=acodec,
-                audio_bitrate=audio_bitrate,
-                map_metadata=map_metadata,
-                write_id3v2=write_id3v2,
+                acodec="libmp3lame",
+                audio_bitrate="320k",
+                map_metadata=0,
+                write_id3v2=1,
             )
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
-
         logger.debug(f"Conversion to mp3 succeeded: {mp3_path}")
         return True
     except FfmpegError as e:
@@ -146,17 +143,14 @@ def update_database_record(
     if output_format.upper() in ["AIFF", "FLAC", "WAV"]:
         converted_bit_depth = converted_audio_info["bit_depth"]
         database_bit_depth = getattr(content, "BitDepth", None)
-        logger.debug(
-            f"Bit depth check: database={database_bit_depth}, file={converted_bit_depth}"
-        )
-
         if (
             database_bit_depth
             and converted_bit_depth
             and converted_bit_depth != database_bit_depth
         ):
             raise Exception(
-                f"Bit depth mismatch for lossless transcode: database={database_bit_depth}, file={converted_bit_depth}"
+                f"Bit depth mismatch for lossless transcode: "
+                f"database={database_bit_depth}, file={converted_bit_depth}"
             )
 
     content.FileNameL = new_filename
@@ -166,28 +160,22 @@ def update_database_record(
     # FLAC stores bitrate as 0 in Rekordbox to represent VBR
     if output_format.upper() == "FLAC":
         content.BitRate = 0
-        logger.debug(
-            f"Set FileType={file_type}, BitRate=0 (FLAC), FolderPath={converted_full_path}"
-        )
     else:
         content.BitRate = converted_bitrate
-        logger.debug(
-            f"Set FileType={file_type}, BitRate={converted_bitrate}, FolderPath={converted_full_path}"
-        )
 
 
-def cleanup_converted_files(converted_files) -> None:
-    """Clean up converted files on error or rollback."""
+def cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
+    """Clean up converted output files on error or rollback."""
     logger.debug("Cleaning up converted files due to aborted conversion.")
-    for file_info in converted_files:
+    for op in converted_ops:
         try:
-            os.remove(file_info["output_path"])
-            logger.debug(f"Cleaned up {file_info['output_path']}")
+            os.remove(op.output_path)
+            logger.debug(f"Cleaned up {op.output_path}")
         except Exception:
             pass
 
 
-def rollback_and_cleanup(db, converted_files) -> None:
+def rollback_and_cleanup(db, converted_ops: list[ConvertOp]) -> None:
     """Roll back the database session and clean up any converted files."""
     logger.debug("Attempting DB session rollback.")
     rollback_error = None
@@ -200,10 +188,8 @@ def rollback_and_cleanup(db, converted_files) -> None:
                 "Check the state of your rekordbox library and consider reverting to a backup database if something's not right"
             )
             rollback_error = e
-    else:
-        logger.debug("No DB session to rollback.")
-    if converted_files:
-        cleanup_converted_files(converted_files)
+    if converted_ops:
+        cleanup_converted_files(converted_ops)
     if rollback_error:
         raise rollback_error
 
@@ -220,149 +206,188 @@ def get_output_path(content, output_format) -> Tuple[str, str, str]:
     return output_path, output_filename, src_dirname
 
 
-# ── Result types ──────────────────────────────────────────────────────────
+# ── Classifier ────────────────────────────────────────────────────────────
 
 
-class ConvertPlan(BaseModel):
-    files: list[Track]
-    skipped: list[Track]  # files skipped due to existing output (no overwrite)
-    should_delete: bool
-    format_out: str
-
-
-class ConvertResult(BaseModel):
-    converted: list[dict]  # {source_path, output_path, content_id}
-    deleted: int
-
-
-# ── API functions ─────────────────────────────────────────────────────────
-
-
-def plan_convert(db: Rekordbox6Database, args: ConvertPlanArgs) -> ConvertPlan:
-    """Determine which tracks need conversion and resolve delete behaviour."""
-    should_delete = (
-        args.delete if args.delete is not None else args.format_out.upper() != "MP3"
-    )
-
-    result = get_filtered_content(db, args)
-    filtered_content = result.scalars().all()
-
-    target_file_type = get_file_type_for_format(args.format_out)
-    mp3_type = get_file_type_for_format("MP3")
-    m4a_type = get_file_type_for_format("M4A")
-
-    needs_conversion = [
-        c
-        for c in filtered_content
-        if c.FileType != target_file_type
-        and c.FileType != mp3_type
-        and c.FileType != m4a_type
-    ]
-
-    if args.overwrite:
-        files = needs_conversion
-        skipped = []
-    else:
-        files, skipped = [], []
-        for content in needs_conversion:
-            output_path, _, _ = get_output_path(content, args.format_out)
-            if os.path.exists(output_path):
-                skipped.append(content)
-            else:
-                files.append(content)
-
-    logger.debug(
-        f"plan_convert: {len(files)} to convert, {len(skipped)} skipped (conflict)"
-    )
-
-    return ConvertPlan(
-        files=[_track_from_content(c) for c in files],
-        skipped=[_track_from_content(c) for c in skipped],
-        should_delete=should_delete,
-        format_out=args.format_out,
+def _classify_convert(content, args: ConvertArgs) -> ConvertOp | SkippedTrack:
+    """Return ConvertOp if this track should be converted, or SkippedTrack with
+    reason if not."""
+    target = get_file_type_for_format(args.format_out)
+    mp3 = get_file_type_for_format("MP3")
+    m4a = get_file_type_for_format("M4A")
+    if content.FileType in (target, mp3, m4a):
+        logger.debug(
+            f"skip convert id={content.ID} reason=already_target_format "
+            f"file_type={content.FileType} target={target}"
+        )
+        return SkippedTrack(id=str(content.ID), reason="already_target_format")
+    output_path, _, _ = get_output_path(content, args.format_out)
+    if not args.overwrite and os.path.exists(output_path):
+        logger.debug(
+            f"skip convert id={content.ID} reason=output_file_exists path={output_path}"
+        )
+        return SkippedTrack(id=str(content.ID), reason="output_file_exists")
+    return ConvertOp(
+        id=str(content.ID),
+        source_path=content.FolderPath or "",
+        output_path=output_path,
     )
 
 
-def convert(db: Rekordbox6Database, plan: ConvertPlan) -> ConvertResult:
-    """Execute a ConvertPlan: convert files and update the database.
+# ── Public API ────────────────────────────────────────────────────────────
 
-    Uses try/except BaseException so KeyboardInterrupt triggers rollback before
-    the exception propagates to the caller.
+
+def convert(
+    db: Rekordbox6Database,
+    args: ConvertArgs,
+    *,
+    dry_run: bool = False,
+) -> ConvertResponse:
+    """Convert audio files to a target format and update the Rekordbox database.
+
+    With `dry_run=True`, returns the planned conversions without any ffmpeg or
+    DB writes. With `dry_run=False` (default), commits the changes.
+
+    The rollback block protects only pre-commit work; once commit lands, the
+    transaction is honoured even if the delete-originals loop or response
+    re-query later fails.
     """
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
-    if not plan.files:
-        return ConvertResult(converted=[], deleted=0)
+    logger.debug(f"convert start format_out={args.format_out} dry_run={dry_run}")
 
     if not ffmpeg_in_path():
+        logger.debug("convert aborted: FFmpeg not in PATH")
         raise RuntimeError(
             f"FFmpeg is required but not found in PATH.{get_ffmpeg_directions()}"
         )
 
+    contents = get_filtered_content(db, args).scalars().all()
+    logger.debug(f"convert fetched {len(contents)} candidate(s) from filter")
+
+    ops: list[ConvertOp] = []
+    skipped: list[SkippedTrack] = []
+    for c in contents:
+        result = _classify_convert(c, args)
+        if isinstance(result, ConvertOp):
+            ops.append(result)
+        else:
+            skipped.append(result)
+    logger.debug(f"convert classified ops={len(ops)} skipped={len(skipped)}")
+
+    if dry_run:
+        logger.debug(f"convert dry-run return with {len(ops)} planned conversion(s)")
+        return ConvertResponse(
+            tracks=_order_tracks_by_op(contents, ops),
+            result=ConvertResult(
+                format_out=args.format_out,
+                converted=ops,
+                deleted=0,
+                skipped=skipped,
+            ),
+        )
+
+    if not ops:
+        return ConvertResponse(
+            tracks=[],
+            result=ConvertResult(
+                format_out=args.format_out,
+                converted=[],
+                deleted=0,
+                skipped=skipped,
+            ),
+        )
+
     assert db.session is not None
 
-    ids = [t.ID for t in plan.files]
-    contents = (
-        db.session.execute(select(DjmdContent).where(DjmdContent.ID.in_(ids)))
-        .scalars()
-        .all()
+    should_delete = (
+        args.delete if args.delete is not None else args.format_out.upper() != "MP3"
     )
+    logger.debug(
+        f"convert should_delete={should_delete} "
+        f"(args.delete={args.delete}, format_out={args.format_out})"
+    )
+
+    # content_map enables per-op live FolderPath / FileNameL reads in the loop.
     content_map = {str(c.ID): c for c in contents}
-
-    converted_files: list[dict] = []
+    converted_ops: list[ConvertOp] = []
     try:
-        for i, track in enumerate(plan.files, 1):
-            content = content_map[track.ID]
-            src_folder_path = content.FolderPath or ""
-            output_path, output_filename, src_dirname = get_output_path(
-                content, plan.format_out
-            )
+        for i, op in enumerate(ops, 1):
+            content = content_map[op.id]
+            src = content.FolderPath or ""
+            logger.info(f"[{i}/{len(ops)}] {content.FileNameL}")
 
-            logger.info(f"[{i}/{len(plan.files)}] {content.FileNameL}")
+            if not os.path.exists(src):
+                raise RuntimeError(f"Source not found: {src}")
 
-            if not os.path.exists(src_folder_path):
-                raise RuntimeError(f"Source not found: {src_folder_path}")
-
-            if plan.format_out.upper() == "MP3":
-                success = convert_to_mp3(src_folder_path, output_path)
+            if args.format_out.upper() == "MP3":
+                success = convert_to_mp3(src, op.output_path)
             else:
                 success = convert_to_lossless(
-                    src_folder_path, output_path, OutputFormats(plan.format_out.lower())
+                    src, op.output_path, OutputFormats(args.format_out.lower())
                 )
 
             if not success:
-                raise RuntimeError(f"Conversion failed for {src_folder_path}")
-
-            if not os.path.exists(output_path):
-                raise RuntimeError(f"Output file not created: {output_path}")
+                raise RuntimeError(f"Conversion failed for {src}")
+            if not os.path.exists(op.output_path):
+                raise RuntimeError(f"Output file not created: {op.output_path}")
 
             update_database_record(
-                db, content.ID, output_filename, src_dirname, plan.format_out.upper()
+                db,
+                op.id,
+                os.path.basename(op.output_path),
+                os.path.dirname(op.output_path),
+                args.format_out.upper(),
             )
-            converted_files.append(
-                {
-                    "source_path": src_folder_path,
-                    "output_path": output_path,
-                    "content_id": content.ID,
-                }
+            converted_ops.append(
+                ConvertOp(id=op.id, source_path=src, output_path=op.output_path)
             )
 
         db.session.commit()
         logger.info(
-            f"\nConverted {len(converted_files)} files to {plan.format_out.upper()}"
+            f"\nConverted {len(converted_ops)} files to {args.format_out.upper()}"
         )
-
-        deleted = 0
-        if plan.should_delete:
-            for file_info in converted_files:
-                try:
-                    os.remove(file_info["source_path"])
-                    deleted += 1
-                except Exception as e:
-                    logger.warning(f"Failed to delete {file_info['source_path']}: {e}")
-
-        return ConvertResult(converted=converted_files, deleted=deleted)
-
+        logger.debug(f"convert committed {len(converted_ops)} conversion(s)")
     except BaseException:
-        rollback_and_cleanup(db, converted_files)
+        logger.debug(
+            f"convert rolling back after {len(converted_ops)} partial conversion(s)"
+        )
+        rollback_and_cleanup(db, converted_ops)
         raise
+
+    deleted = 0
+    if should_delete:
+        for op in converted_ops:
+            try:
+                os.remove(op.source_path)
+                deleted += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete {op.source_path}: {e}")
+        logger.debug(f"convert deleted {deleted}/{len(converted_ops)} source file(s)")
+
+    converted_ids = [op.id for op in converted_ops]
+    try:
+        post_contents = (
+            db.session.execute(
+                select(DjmdContent).where(DjmdContent.ID.in_(converted_ids))
+            )
+            .scalars()
+            .all()
+        )
+        logger.debug(
+            f"convert post-commit re-query returned {len(post_contents)} track(s)"
+        )
+        tracks = _order_tracks_by_op(post_contents, converted_ops)
+    except Exception as e:
+        logger.warning(f"Failed to re-query tracks after commit: {e}")
+        tracks = []
+
+    return ConvertResponse(
+        tracks=tracks,
+        result=ConvertResult(
+            format_out=args.format_out,
+            converted=converted_ops,
+            deleted=deleted,
+            skipped=skipped,
+        ),
+    )

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -1,12 +1,17 @@
+"""Edit API for rekordbox-edit."""
+
 import logging
 
-from pydantic import BaseModel
 from pyrekordbox import Rekordbox6Database
-from pyrekordbox.db6 import DjmdContent
-from sqlalchemy import select
 
-from rekordbox_edit.api._utils import _track_from_content
-from rekordbox_edit.models import EditPlanArgs, Track
+from rekordbox_edit.api._utils import _order_tracks_by_op
+from rekordbox_edit.models import (
+    EditArgs,
+    EditOp,
+    EditResponse,
+    EditResult,
+    SkippedTrack,
+)
 from rekordbox_edit.query import get_filtered_content
 
 logger = logging.getLogger(__name__)
@@ -28,61 +33,77 @@ def _compute_new_value(
     return replace_value
 
 
-class EditPlan(BaseModel):
-    field: str
-    edits: list[tuple[Track, str]]
-
-
-class EditResult(BaseModel):
-    applied: int
-
-
-def plan_edit(db: Rekordbox6Database, args: EditPlanArgs) -> EditPlan:
-    """Compute which tracks would be changed and their new values.
-
-    Raises ValueError if more than one track matches and args.multi is False.
-    """
-    result = get_filtered_content(db, args)
-    tracks = result.scalars().all()
-
+def _classify_edit(content, args: EditArgs) -> EditOp | SkippedTrack:
+    """Return EditOp if this track should be edited, or SkippedTrack with
+    reason if not."""
     col_name = FIELD_COLUMNS[args.field]
-    edits: list[tuple[Track, str]] = []
-    for content in tracks:
-        current = getattr(content, col_name)
-        new_value = _compute_new_value(current, args.match_pattern, args.replace_value)
-        if new_value is None or new_value == current:
-            continue
-        edits.append((_track_from_content(content), str(new_value)))
+    current = getattr(content, col_name)
+    new_value = _compute_new_value(current, args.match_pattern, args.replace_value)
+    if new_value is None or new_value == current:
+        logger.debug(
+            f"skip edit id={content.ID} reason=no_change "
+            f"field={args.field} current={current!r}"
+        )
+        return SkippedTrack(id=str(content.ID), reason="no_change")
+    return EditOp(id=str(content.ID), new_value=str(new_value))
 
-    if len(edits) > 1 and not args.multi:
+
+def edit(
+    db: Rekordbox6Database,
+    args: EditArgs,
+    *,
+    dry_run: bool = False,
+) -> EditResponse:
+    """Apply a metadata edit across tracks matching the filter args.
+
+    With `dry_run=True`, returns the planned edits without any DB writes.
+    With `dry_run=False` (default), commits the changes.
+    """
+    logger.debug(f"edit start field={args.field} dry_run={dry_run}")
+    contents = get_filtered_content(db, args).scalars().all()
+    logger.debug(f"edit fetched {len(contents)} candidate(s) from filter")
+
+    ops: list[EditOp] = []
+    skipped: list[SkippedTrack] = []
+    for c in contents:
+        result = _classify_edit(c, args)
+        if isinstance(result, EditOp):
+            ops.append(result)
+        else:
+            skipped.append(result)
+    logger.debug(f"edit classified ops={len(ops)} skipped={len(skipped)}")
+
+    if len(ops) > 1 and not args.multi:
+        logger.debug(f"edit aborted on multi guard with {len(ops)} ops")
         raise ValueError(
-            f"Found {len(edits)} tracks that would be edited. "
+            f"Found {len(ops)} tracks that would be edited. "
             "Refine your filters, use dry_run to inspect, or pass multi=True to edit all."
         )
 
-    logger.debug(f"plan_edit: {len(edits)} edit(s) planned for field '{args.field}'")
-    return EditPlan(field=args.field, edits=edits)
+    if dry_run:
+        logger.debug(f"edit dry-run return with {len(ops)} planned edit(s)")
+        return EditResponse(
+            tracks=_order_tracks_by_op(contents, ops),
+            result=EditResult(field=args.field, edits=ops, skipped=skipped),
+        )
 
-
-def edit(db: Rekordbox6Database, plan: EditPlan) -> EditResult:
-    if not plan.edits:
-        return EditResult(applied=0)
+    if not ops:
+        return EditResponse(
+            tracks=[],
+            result=EditResult(field=args.field, edits=[], skipped=skipped),
+        )
 
     assert db.session is not None
 
-    col_name = FIELD_COLUMNS[plan.field]
-    ids = [track.ID for track, _ in plan.edits]
-    new_values = {track.ID: new_val for track, new_val in plan.edits}
-
-    contents = (
-        db.session.execute(select(DjmdContent).where(DjmdContent.ID.in_(ids)))
-        .scalars()
-        .all()
-    )
-
+    col_name = FIELD_COLUMNS[args.field]
+    new_values = {op.id: op.new_value for op in ops}
     for content in contents:
-        setattr(content, col_name, new_values[str(content.ID)])
-
+        if str(content.ID) in new_values:
+            setattr(content, col_name, new_values[str(content.ID)])
     db.session.commit()
-    logger.debug(f"edit: committed {len(contents)} change(s)")
-    return EditResult(applied=len(contents))
+    logger.debug(f"edit committed {len(ops)} change(s) on field={args.field}")
+
+    return EditResponse(
+        tracks=_order_tracks_by_op(contents, ops),
+        result=EditResult(field=args.field, edits=ops, skipped=skipped),
+    )

--- a/rekordbox_edit/api/search.py
+++ b/rekordbox_edit/api/search.py
@@ -1,10 +1,19 @@
+"""Search API for rekordbox-edit."""
+
+import logging
+
 from pyrekordbox import Rekordbox6Database
 
 from rekordbox_edit.api._utils import _track_from_content
-from rekordbox_edit.models import FilterArgs, Track
+from rekordbox_edit.models import SearchArgs, SearchResponse
 from rekordbox_edit.query import get_filtered_content
 
+logger = logging.getLogger(__name__)
 
-def search(db: Rekordbox6Database, args: FilterArgs) -> list[Track]:
+
+def search(db: Rekordbox6Database, args: SearchArgs) -> SearchResponse:
+    logger.debug("search start")
     result = get_filtered_content(db, args)
-    return [_track_from_content(c) for c in result.scalars().all()]
+    tracks = [_track_from_content(c) for c in result.scalars().all()]
+    logger.debug(f"search returning {len(tracks)} track(s)")
+    return SearchResponse(tracks=tracks)

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,16 +1,13 @@
-"""Shared CLI utilities: stdin handling, scripting guards, confirmation flows."""
+"""CLI-private helpers: stdin handling, scripting guards, args narrowing, print emitters."""
 
-import json
 import logging
 import sys
+from copy import copy
 
 import click
+from pydantic import BaseModel
 
 from rekordbox_edit._click import PrintChoice
-from rekordbox_edit.api.convert import ConvertPlan
-from rekordbox_edit.api.edit import EditPlan
-from rekordbox_edit.models import ConvertCommandArgs, EditCommandArgs, Track
-from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +29,7 @@ def _handle_stdin(args) -> bool:
 
 
 def _validate_scripting_preconditions(print_opt, args, piped_stdin: bool) -> None:
-    """Raise UsageError for invalid scripting mode combinations."""
+    """Raise UsageError for invalid scripting-mode combinations."""
     if print_opt in SCRIPTING_MODES and not (args.dry_run or args.yes):
         raise click.UsageError(
             "--print=ids, --print=silent, or --print=json requires --dry-run or --yes to skip confirmation"
@@ -41,77 +38,42 @@ def _validate_scripting_preconditions(print_opt, args, piped_stdin: bool) -> Non
         raise click.UsageError("Piping track IDs requires --dry-run or --yes")
 
 
-def _print_ids(print_opt, ids: list[str]) -> None:
-    """Print space-separated IDs if print_opt is IDS."""
-    if print_opt is PrintChoice.IDS:
-        print(" ".join(ids))
+def _narrow_to_track_ids(args, ids: list[str]):
+    """Return a new args of the same type with track_ids=ids and all other
+    FilterArgs criteria cleared, preserving command-specific fields.
+
+    Used when the CLI's interactive mode has trimmed the planned operation
+    to a user-selected subset. The narrowed args is passed to the real-run
+    call so the second pass only considers the chosen track IDs.
+    """
+    narrowed = copy(args)
+    for field_name in (
+        "track_id",
+        "track_ids",
+        "title",
+        "exact_title",
+        "playlist",
+        "exact_playlist",
+        "artist",
+        "exact_artist",
+        "album",
+        "exact_album",
+        "path",
+        "exact_path",
+        "format",
+    ):
+        if hasattr(narrowed, field_name):
+            setattr(narrowed, field_name, [])
+    narrowed.track_ids = list(ids)
+    narrowed.match_all = False
+    return narrowed
 
 
-def _print_tracks_json(print_opt, tracks: list[Track]) -> None:
-    """Print tracks as a single JSON array if print_opt is JSON."""
-    if print_opt is PrintChoice.JSON:
-        print(json.dumps([t.model_dump(mode="json") for t in tracks]))
+def _print_response_ids(response) -> None:
+    """Print space-separated IDs from response.tracks."""
+    print(" ".join(t.ID for t in response.tracks))
 
 
-def _confirm_edits(plan: EditPlan, args: EditCommandArgs) -> EditPlan | None:
-    """Gate the edit plan through user confirmation. Returns None if cancelled."""
-    if args.yes:
-        return plan
-    if args.interactive:
-        return _interactive_filter_edits(plan)
-    try:
-        if not confirm(f"Apply {len(plan.edits)} edit(s)?", default=True):
-            logger.info("Cancelled.")
-            return None
-    except UserQuit:
-        return None
-    return plan
-
-
-def _interactive_filter_edits(plan: EditPlan) -> EditPlan:
-    """Prompt for each edit individually and return a plan with only confirmed edits."""
-    confirmed = []
-    for track, new_val in plan.edits:
-        try:
-            if confirm(f"  Edit {track.ID}?", default=True):
-                confirmed.append((track, new_val))
-        except UserQuit:
-            break
-    return EditPlan(field=plan.field, edits=confirmed)
-
-
-def _confirm_converts(
-    plan: ConvertPlan, args: ConvertCommandArgs
-) -> ConvertPlan | None:
-    """Gate the convert plan through user confirmation. Returns None if cancelled."""
-    if args.yes:
-        return plan
-    if args.interactive:
-        return _interactive_filter_converts(plan)
-    try:
-        if not confirm(
-            f"Convert {len(plan.files)} files to {plan.format_out.upper()}?",
-            default=True,
-        ):
-            logger.info("Cancelled.")
-            return None
-    except UserQuit:
-        return None
-    return plan
-
-
-def _interactive_filter_converts(plan: ConvertPlan) -> ConvertPlan:
-    """Prompt for each file individually and return a plan with only confirmed files."""
-    confirmed = []
-    for track in plan.files:
-        try:
-            if confirm(f"  Convert {track.FileNameL}?", default=True):
-                confirmed.append(track)
-        except UserQuit:
-            break
-    return ConvertPlan(
-        files=confirmed,
-        skipped=plan.skipped,
-        should_delete=plan.should_delete,
-        format_out=plan.format_out,
-    )
+def _print_response_json(response: BaseModel) -> None:
+    """Print the response envelope as JSON."""
+    print(response.model_dump_json())

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,5 +1,6 @@
 """Shared CLI utilities: stdin handling, scripting guards, confirmation flows."""
 
+import json
 import logging
 import sys
 
@@ -8,10 +9,12 @@ import click
 from rekordbox_edit._click import PrintChoice
 from rekordbox_edit.api.convert import ConvertPlan
 from rekordbox_edit.api.edit import EditPlan
-from rekordbox_edit.models import ConvertCommandArgs, EditCommandArgs
+from rekordbox_edit.models import ConvertCommandArgs, EditCommandArgs, Track
 from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
+
+SCRIPTING_MODES = (PrintChoice.IDS, PrintChoice.SILENT, PrintChoice.JSON)
 
 
 def _handle_stdin(args) -> bool:
@@ -30,10 +33,9 @@ def _handle_stdin(args) -> bool:
 
 def _validate_scripting_preconditions(print_opt, args, piped_stdin: bool) -> None:
     """Raise UsageError for invalid scripting mode combinations."""
-    scripting_mode = print_opt in (PrintChoice.IDS, PrintChoice.SILENT)
-    if scripting_mode and not (args.dry_run or args.yes):
+    if print_opt in SCRIPTING_MODES and not (args.dry_run or args.yes):
         raise click.UsageError(
-            "--print=ids or --print=silent requires --dry-run or --yes to skip confirmation"
+            "--print=ids, --print=silent, or --print=json requires --dry-run or --yes to skip confirmation"
         )
     if piped_stdin and not (args.dry_run or args.yes):
         raise click.UsageError("Piping track IDs requires --dry-run or --yes")
@@ -43,6 +45,12 @@ def _print_ids(print_opt, ids: list[str]) -> None:
     """Print space-separated IDs if print_opt is IDS."""
     if print_opt is PrintChoice.IDS:
         print(" ".join(ids))
+
+
+def _print_tracks_json(print_opt, tracks: list[Track]) -> None:
+    """Print tracks as a single JSON array if print_opt is JSON."""
+    if print_opt is PrintChoice.JSON:
+        print(json.dumps([t.model_dump(mode="json") for t in tracks]))
 
 
 def _confirm_edits(plan: EditPlan, args: EditCommandArgs) -> EditPlan | None:

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -8,7 +8,6 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.utils import get_rekordbox_pid
 
 from rekordbox_edit._click import (
-    PrintChoice,
     add_click_options,
     convert_click_options,
     global_click_confirmations,
@@ -19,9 +18,11 @@ from rekordbox_edit._click import (
 from rekordbox_edit.api.convert import convert, plan_convert
 from rekordbox_edit.models import ConvertCommandArgs
 from rekordbox_edit.cli._utils import (
+    SCRIPTING_MODES,
     _confirm_converts,
     _handle_stdin,
     _print_ids,
+    _print_tracks_json,
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
@@ -57,7 +58,7 @@ def convert_command(**kwargs):
     piped_stdin = _handle_stdin(args)
     _validate_scripting_preconditions(print_opt, args, piped_stdin)
 
-    scripting_mode = print_opt in (PrintChoice.IDS, PrintChoice.SILENT)
+    scripting_mode = print_opt in SCRIPTING_MODES
 
     rekordbox_pid = get_rekordbox_pid()
     if rekordbox_pid:
@@ -88,15 +89,19 @@ def convert_command(**kwargs):
         logger.info("No files need conversion.")
         return
 
-    logger.info(f"Found {len(plan.files)} files to convert to {plan.format_out.upper()}")
-    print_track_info(
-        plan.files,
-        changed_field=PrintableField.FileType,
-        new_values=[plan.format_out.upper()] * len(plan.files),
+    logger.info(
+        f"Found {len(plan.files)} files to convert to {plan.format_out.upper()}"
     )
+    if not scripting_mode:
+        print_track_info(
+            plan.files,
+            changed_field=PrintableField.FileType,
+            new_values=[plan.format_out.upper()] * len(plan.files),
+        )
 
     if args.dry_run:
         _print_ids(print_opt, [t.ID for t in plan.files])
+        _print_tracks_json(print_opt, plan.files)
         return
 
     confirmed = _confirm_converts(plan, args)
@@ -107,4 +112,7 @@ def convert_command(**kwargs):
     logger.info(f"Converted {len(result.converted)} files to {plan.format_out.upper()}")
     if result.deleted:
         logger.info(f"Deleted {result.deleted} original file(s)")
+    converted_ids = {str(f["content_id"]) for f in result.converted}
+    converted_tracks = [t for t in confirmed.files if t.ID in converted_ids]
     _print_ids(print_opt, [str(f["content_id"]) for f in result.converted])
+    _print_tracks_json(print_opt, converted_tracks)

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -138,8 +138,6 @@ def convert_command(**kwargs):
             return
         response = convert(db, args)
 
-    if response.result.deleted:
-        logger.info(f"Deleted {response.result.deleted} original file(s)")
     _render_convert_response(response, print_opt, scripting_mode, dry_run=False)
 
 

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -86,11 +86,10 @@ def convert_command(**kwargs):
 
     db = Rekordbox6Database()
 
-    # --yes or --dry-run: one call.
     if yes or dry_run:
         response = convert(db, args, dry_run=dry_run)
         _report_skips(response.result.skipped)
-        _render_convert_response(response, print_opt, scripting_mode, dry_run=dry_run)
+        _print_convert_result(response, print_opt, scripting_mode, dry_run=dry_run)
         return
 
     # Default / interactive: preview first.
@@ -138,7 +137,7 @@ def convert_command(**kwargs):
             return
         response = convert(db, args)
 
-    _render_convert_response(response, print_opt, scripting_mode, dry_run=False)
+    _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
 
 
 def _report_skips(skipped) -> None:
@@ -152,7 +151,7 @@ def _report_skips(skipped) -> None:
         )
 
 
-def _render_convert_response(
+def _print_convert_result(
     response, print_opt, scripting_mode, *, dry_run: bool
 ) -> None:
     if not dry_run:

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -8,6 +8,7 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.utils import get_rekordbox_pid
 
 from rekordbox_edit._click import (
+    PrintChoice,
     add_click_options,
     convert_click_options,
     global_click_confirmations,
@@ -15,18 +16,18 @@ from rekordbox_edit._click import (
     print_option,
     track_ids_argument,
 )
-from rekordbox_edit.api.convert import convert, plan_convert
-from rekordbox_edit.models import ConvertCommandArgs
+from rekordbox_edit.api.convert import convert
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
-    _confirm_converts,
     _handle_stdin,
-    _print_ids,
-    _print_tracks_json,
+    _narrow_to_track_ids,
+    _print_response_ids,
+    _print_response_json,
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.models import ConvertArgs
 from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
@@ -48,15 +49,21 @@ def convert_command(**kwargs):
     """Convert lossless audio files between formats and update RekordBox database.
 
     Supports conversion from any lossless format (FLAC, AIFF, WAV) to:
-    AIFF, FLAC, WAV, ALAC, or MP3.
-
-    Skips lossy formats and files already in the target format.
+    AIFF, FLAC, WAV, ALAC, or MP3. Skips lossy formats and files already in
+    the target format.
     """
     print_opt = kwargs.pop("print_opt", None)
-    args = ConvertCommandArgs(**kwargs)
+    dry_run = kwargs.pop("dry_run", False)
+    yes = kwargs.pop("yes", False)
+    interactive = kwargs.pop("interactive", False)
+    args = ConvertArgs(**kwargs)
     set_level(print_opt)
     piped_stdin = _handle_stdin(args)
-    _validate_scripting_preconditions(print_opt, args, piped_stdin)
+    _validate_scripting_preconditions(
+        print_opt,
+        type("_S", (), {"dry_run": dry_run, "yes": yes})(),
+        piped_stdin,
+    )
 
     scripting_mode = print_opt in SCRIPTING_MODES
 
@@ -78,41 +85,92 @@ def convert_command(**kwargs):
             return
 
     db = Rekordbox6Database()
-    plan = plan_convert(db, args)
 
-    if plan.skipped:
-        logger.warning(
-            f"Skipping {len(plan.skipped)} file(s) (output exists, use --overwrite)"
-        )
+    # --yes or --dry-run: one call.
+    if yes or dry_run:
+        response = convert(db, args, dry_run=dry_run)
+        _report_skips(response.result.skipped)
+        _render_convert_response(response, print_opt, scripting_mode, dry_run=dry_run)
+        return
 
-    if not plan.files:
+    # Default / interactive: preview first.
+    preview = convert(db, args, dry_run=True)
+    _report_skips(preview.result.skipped)
+
+    if not preview.result.converted:
         logger.info("No files need conversion.")
         return
 
     logger.info(
-        f"Found {len(plan.files)} files to convert to {plan.format_out.upper()}"
+        f"Found {len(preview.result.converted)} files to convert to "
+        f"{preview.result.format_out.upper()}"
     )
     if not scripting_mode:
         print_track_info(
-            plan.files,
+            preview.tracks,
             changed_field=PrintableField.FileType,
-            new_values=[plan.format_out.upper()] * len(plan.files),
+            new_values=[preview.result.format_out.upper()] * len(preview.tracks),
         )
 
-    if args.dry_run:
-        _print_ids(print_opt, [t.ID for t in plan.files])
-        _print_tracks_json(print_opt, plan.files)
-        return
+    if interactive:
+        selected_ids = []
+        for track, op in zip(preview.tracks, preview.result.converted):
+            try:
+                if confirm(f"  Convert {track.FileNameL}?", default=True):
+                    selected_ids.append(op.id)
+            except UserQuit:
+                break
+        if not selected_ids:
+            logger.info("Cancelled.")
+            return
+        narrowed = _narrow_to_track_ids(args, selected_ids)
+        response = convert(db, narrowed)
+    else:
+        try:
+            if not confirm(
+                f"Convert {len(preview.result.converted)} files to "
+                f"{preview.result.format_out.upper()}?",
+                default=True,
+            ):
+                logger.info("Cancelled.")
+                return
+        except UserQuit:
+            return
+        response = convert(db, args)
 
-    confirmed = _confirm_converts(plan, args)
-    if confirmed is None:
-        return
+    if response.result.deleted:
+        logger.info(f"Deleted {response.result.deleted} original file(s)")
+    _render_convert_response(response, print_opt, scripting_mode, dry_run=False)
 
-    result = convert(db, confirmed)
-    logger.info(f"Converted {len(result.converted)} files to {plan.format_out.upper()}")
-    if result.deleted:
-        logger.info(f"Deleted {result.deleted} original file(s)")
-    converted_ids = {str(f["content_id"]) for f in result.converted}
-    converted_tracks = [t for t in confirmed.files if t.ID in converted_ids]
-    _print_ids(print_opt, [str(f["content_id"]) for f in result.converted])
-    _print_tracks_json(print_opt, converted_tracks)
+
+def _report_skips(skipped) -> None:
+    already_target = sum(1 for s in skipped if s.reason == "already_target_format")
+    conflicts = sum(1 for s in skipped if s.reason == "output_file_exists")
+    if already_target:
+        logger.warning(f"Skipping {already_target} file(s): already in target format")
+    if conflicts:
+        logger.warning(
+            f"Skipping {conflicts} file(s): output exists (use --overwrite to convert)"
+        )
+
+
+def _render_convert_response(
+    response, print_opt, scripting_mode, *, dry_run: bool
+) -> None:
+    if not dry_run:
+        logger.info(
+            f"Converted {len(response.result.converted)} files to "
+            f"{response.result.format_out.upper()}"
+        )
+        if response.result.deleted:
+            logger.info(f"Deleted {response.result.deleted} original file(s)")
+    if print_opt == PrintChoice.IDS:
+        _print_response_ids(response)
+    elif print_opt == PrintChoice.JSON:
+        _print_response_json(response)
+    elif not scripting_mode and dry_run:
+        print_track_info(
+            response.tracks,
+            changed_field=PrintableField.FileType,
+            new_values=[response.result.format_out.upper()] * len(response.tracks),
+        )

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -67,7 +67,6 @@ def edit_command(**kwargs):
 
     db = Rekordbox6Database()
 
-    # --yes or --dry-run: one call, no preview prompt.
     if yes or dry_run:
         try:
             response = edit(db, args, dry_run=dry_run)
@@ -78,7 +77,7 @@ def edit_command(**kwargs):
             logger.info("No changes to make.")
             return
 
-        _render_edit_response(response, print_opt, dry_run=dry_run)
+        _print_edit_result(response, print_opt, dry_run=dry_run)
         return
 
     # Default / interactive: preview first.
@@ -120,10 +119,10 @@ def edit_command(**kwargs):
             return
         response = edit(db, args)
 
-    _render_edit_response(response, print_opt, dry_run=False)
+    _print_edit_result(response, print_opt, dry_run=False)
 
 
-def _render_edit_response(response, print_opt, *, dry_run: bool) -> None:
+def _print_edit_result(response, print_opt, *, dry_run: bool) -> None:
     if not dry_run:
         logger.info(f"Applied {len(response.result.edits)} edit(s).")
     if print_opt == PrintChoice.IDS:

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -74,6 +74,10 @@ def edit_command(**kwargs):
         except ValueError as e:
             raise click.UsageError(str(e)) from e
 
+        if not response.result.edits and not dry_run:
+            logger.info("No changes to make.")
+            return
+
         _render_edit_response(response, print_opt, dry_run=dry_run)
         return
 

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -1,9 +1,12 @@
+"""Edit CLI command."""
+
 import logging
 
 import click
 from pyrekordbox import Rekordbox6Database
 
 from rekordbox_edit._click import (
+    PrintChoice,
     add_click_options,
     edit_click_options,
     global_click_confirmations,
@@ -11,18 +14,19 @@ from rekordbox_edit._click import (
     print_option,
     track_ids_argument,
 )
-from rekordbox_edit.api.edit import FIELD_COLUMNS, edit, plan_edit
-from rekordbox_edit.models import EditCommandArgs
+from rekordbox_edit.api.edit import FIELD_COLUMNS, edit
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
-    _confirm_edits,
     _handle_stdin,
-    _print_ids,
-    _print_tracks_json,
+    _narrow_to_track_ids,
+    _print_response_ids,
+    _print_response_json,
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.models import EditArgs
+from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -46,38 +50,87 @@ logger = logging.getLogger(__name__)
 def edit_command(**kwargs):
     """Edit a metadata field on tracks in the RekordBox database."""
     print_opt = kwargs.pop("print_opt", None)
-    args = EditCommandArgs(**kwargs)
+    # CLI-only flags pulled out of kwargs before constructing EditArgs.
+    dry_run = kwargs.pop("dry_run", False)
+    yes = kwargs.pop("yes", False)
+    interactive = kwargs.pop("interactive", False)
+    args = EditArgs(**kwargs)
     set_level(print_opt)
     piped_stdin = _handle_stdin(args)
-    _validate_scripting_preconditions(print_opt, args, piped_stdin)
+
+    # Sentinel object mirrors the old ConfirmationArgs shape for the validator.
+    _validate_scripting_preconditions(
+        print_opt,
+        type("_S", (), {"dry_run": dry_run, "yes": yes})(),
+        piped_stdin,
+    )
 
     db = Rekordbox6Database()
+
+    # --yes or --dry-run: one call, no preview prompt.
+    if yes or dry_run:
+        try:
+            response = edit(db, args, dry_run=dry_run)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
+
+        _render_edit_response(response, print_opt, dry_run=dry_run)
+        return
+
+    # Default / interactive: preview first.
     try:
-        plan = plan_edit(db, args)
+        preview = edit(db, args, dry_run=True)
     except ValueError as e:
         raise click.UsageError(str(e)) from e
 
-    if not plan.edits:
+    if not preview.result.edits:
         logger.info("No changes to make.")
         return
 
     if print_opt not in SCRIPTING_MODES:
         print_track_info(
-            [t for t, _ in plan.edits],
-            changed_field=PrintableField[plan.field],
-            new_values=[v for _, v in plan.edits],
+            preview.tracks,
+            changed_field=PrintableField[preview.result.field],
+            new_values=[op.new_value for op in preview.result.edits],
         )
 
-    if args.dry_run:
-        _print_ids(print_opt, [t.ID for t, _ in plan.edits])
-        _print_tracks_json(print_opt, [t for t, _ in plan.edits])
-        return
+    if interactive:
+        selected_ids = []
+        for track, op in zip(preview.tracks, preview.result.edits):
+            try:
+                if confirm(f"  Edit {track.ID}?", default=True):
+                    selected_ids.append(op.id)
+            except UserQuit:
+                break
+        if not selected_ids:
+            logger.info("Cancelled.")
+            return
+        narrowed = _narrow_to_track_ids(args, selected_ids)
+        response = edit(db, narrowed)
+    else:
+        try:
+            if not confirm(f"Apply {len(preview.result.edits)} edit(s)?", default=True):
+                logger.info("Cancelled.")
+                return
+        except UserQuit:
+            return
+        response = edit(db, args)
 
-    confirmed = _confirm_edits(plan, args)
-    if confirmed is None:
-        return
+    _render_edit_response(response, print_opt, dry_run=False)
 
-    result = edit(db, confirmed)
-    logger.info(f"Applied {result.applied} edit(s).")
-    _print_ids(print_opt, [t.ID for t, _ in confirmed.edits])
-    _print_tracks_json(print_opt, [t for t, _ in confirmed.edits])
+
+def _render_edit_response(response, print_opt, *, dry_run: bool) -> None:
+    if not dry_run:
+        logger.info(f"Applied {len(response.result.edits)} edit(s).")
+    if print_opt == PrintChoice.IDS:
+        _print_response_ids(response)
+    elif print_opt == PrintChoice.JSON:
+        _print_response_json(response)
+    elif print_opt not in SCRIPTING_MODES and dry_run:
+        # Preview already rendered above in default flow; explicit --dry-run
+        # path with no print_opt renders here.
+        print_track_info(
+            response.tracks,
+            changed_field=PrintableField[response.result.field],
+            new_values=[op.new_value for op in response.result.edits],
+        )

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -14,9 +14,11 @@ from rekordbox_edit._click import (
 from rekordbox_edit.api.edit import FIELD_COLUMNS, edit, plan_edit
 from rekordbox_edit.models import EditCommandArgs
 from rekordbox_edit.cli._utils import (
+    SCRIPTING_MODES,
     _confirm_edits,
     _handle_stdin,
     _print_ids,
+    _print_tracks_json,
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
@@ -59,14 +61,16 @@ def edit_command(**kwargs):
         logger.info("No changes to make.")
         return
 
-    print_track_info(
-        [t for t, _ in plan.edits],
-        changed_field=PrintableField[plan.field],
-        new_values=[v for _, v in plan.edits],
-    )
+    if print_opt not in SCRIPTING_MODES:
+        print_track_info(
+            [t for t, _ in plan.edits],
+            changed_field=PrintableField[plan.field],
+            new_values=[v for _, v in plan.edits],
+        )
 
     if args.dry_run:
         _print_ids(print_opt, [t.ID for t, _ in plan.edits])
+        _print_tracks_json(print_opt, [t for t, _ in plan.edits])
         return
 
     confirmed = _confirm_edits(plan, args)
@@ -76,3 +80,4 @@ def edit_command(**kwargs):
     result = edit(db, confirmed)
     logger.info(f"Applied {result.applied} edit(s).")
     _print_ids(print_opt, [t.ID for t, _ in confirmed.edits])
+    _print_tracks_json(print_opt, [t for t, _ in confirmed.edits])

--- a/rekordbox_edit/cli/search.py
+++ b/rekordbox_edit/cli/search.py
@@ -12,7 +12,7 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.api.search import search
 from rekordbox_edit.models import FilterArgs
-from rekordbox_edit.cli._utils import _handle_stdin, _print_ids
+from rekordbox_edit.cli._utils import _handle_stdin, _print_ids, _print_tracks_json
 from rekordbox_edit.display import print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
 
@@ -37,5 +37,8 @@ def search_command(**kwargs):
         return
     if print_opt is PrintChoice.IDS:
         _print_ids(print_opt, [t.ID for t in tracks])
+        return
+    if print_opt is PrintChoice.JSON:
+        _print_tracks_json(print_opt, tracks)
         return
     print_track_info(tracks)

--- a/rekordbox_edit/cli/search.py
+++ b/rekordbox_edit/cli/search.py
@@ -1,3 +1,5 @@
+"""Search CLI command."""
+
 import logging
 
 import click
@@ -11,10 +13,14 @@ from rekordbox_edit._click import (
     track_ids_argument,
 )
 from rekordbox_edit.api.search import search
-from rekordbox_edit.models import FilterArgs
-from rekordbox_edit.cli._utils import _handle_stdin, _print_ids, _print_tracks_json
+from rekordbox_edit.cli._utils import (
+    _handle_stdin,
+    _print_response_ids,
+    _print_response_json,
+)
 from rekordbox_edit.display import print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.models import SearchArgs
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +32,19 @@ logger = logging.getLogger(__name__)
 def search_command(**kwargs):
     """Search the RekordBox database."""
     print_opt = kwargs.pop("print_opt", None)
-    args = FilterArgs(**kwargs)
+    args = SearchArgs(**kwargs)
     set_level(print_opt)
     _handle_stdin(args)
 
     db = Rekordbox6Database()
-    tracks = search(db, args)
+    response = search(db, args)
 
     if print_opt is PrintChoice.SILENT:
         return
     if print_opt is PrintChoice.IDS:
-        _print_ids(print_opt, [t.ID for t in tracks])
+        _print_response_ids(response)
         return
     if print_opt is PrintChoice.JSON:
-        _print_tracks_json(print_opt, tracks)
+        _print_response_json(response)
         return
-    print_track_info(tracks)
+    print_track_info(response.tracks)

--- a/rekordbox_edit/logger.py
+++ b/rekordbox_edit/logger.py
@@ -50,7 +50,7 @@ def set_level(level: PrintChoice | None) -> None:
 
     if _console_handler is None:
         return
-    if level in (PrintChoice.SILENT, PrintChoice.IDS):
+    if level in (PrintChoice.SILENT, PrintChoice.IDS, PrintChoice.JSON):
         _console_handler.setLevel(logging.ERROR)
     elif level == PrintChoice.DEBUG:
         _console_handler.setLevel(logging.DEBUG)

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -94,20 +94,35 @@ class Track(BaseModel):
     Field names mirror DjmdContent column names so conversion is a mechanical
     field copy with no translation. This type is the sole return type of the
     API layer — ORM objects never cross the API boundary.
+
+    `extra="allow"` lets `_track_from_content` bulk-copy every DjmdContent
+    column without enumerating each one; the declared fields below stay typed
+    and validated, undeclared columns ride along as untyped attributes.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
-    ID: str
-    Title: str | None = None
-    ArtistName: str | None = None
     AlbumName: str | None = None
-    FileNameL: str | None = None
-    FolderPath: str | None = None
-    FileType: int | None = None
-    SampleRate: int | None = None
+    Analysed: int | None = None
+    AnalysisUpdated: str | None = None
+    ArtistName: str | None = None
     BitDepth: int | None = None
     BitRate: int | None = None
+    Commnt: str | None = None
+    DateCreated: str | None = None
+    FileNameL: str
+    FileNameS: str | None = None
+    FileType: int | None = None
+    FolderPath: str
+    ID: str
+    Length: int | None = None
+    Rating: int | None = None
+    ReleaseDate: str | None = None
+    ReleaseYear: int | None = None
+    SampleRate: int | None = None
+    Tag: str | None = None
+    Title: str | None = None
+    TrackNo: int | None = None
 
 
 class EditPlanArgs(FilterArgs, EditArgs):

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -1,28 +1,36 @@
-"""Pydantic models for the public API and CLI argument groups.
+"""Pydantic models for the public API.
 
-Four layers:
+Three layers:
 
-- **Component models** (`FilterArgs`, `ConfirmationArgs`, `EditArgs`,
-  `ConvertArgs`) declare cohesive subsets of inputs.
-- **API contract types** (`EditPlanArgs`, `ConvertPlanArgs`) compose
-  component models into the typed inputs that `plan_edit` and `plan_convert`
-  accept. They contain no CLI-specific fields.
-- **Command models** (`EditCommandArgs`, `ConvertCommandArgs`) extend the
-  API types with `ConfirmationArgs` for CLI use.
-- **Domain model** (`Track`) is the sole return type of the API layer.
-  Field names mirror DjmdContent column names so conversion is mechanical.
+- **Filter base** (`FilterArgs`) declares track-selection criteria shared by all
+  commands.
+- **Command args** (`SearchArgs`, `EditArgs`, `ConvertArgs`) extend `FilterArgs`
+  with command-specific fields.
+- **Domain types** (`Track`, `EditOp`, `ConvertOp`, `SkippedTrack`) and
+  **response envelopes** (`SearchResponse`, `EditResponse`, `ConvertResponse`)
+  describe what each command returns.
+
+Envelope semantics:
+
+- `tracks` always reflects the **current DB state** at the moment the response
+  was built. Pre-execute for dry-runs, post-execute for write runs.
+- `result` summarizes what happened (or would happen in a dry-run). Result
+  envelopes carry operation identity (the field name for edit, the target
+  format for convert) so a response is fully self-describing.
+- `tracks` and `result.edits` / `result.converted` align 1:1 by index;
+  validators enforce equal lengths.
 """
 
-from pydantic import BaseModel, ConfigDict
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+# ── Filter base ───────────────────────────────────────────────────────────
 
 
 class FilterArgs(BaseModel):
-    """Filter inputs forwarded to `get_filtered_content`.
-
-    Field names mirror the Click parameter names: `track_ids` holds the
-    positional TRACK_IDS argument (variadic), `track_id` holds the values of
-    the repeated `--track-id` option.
-    """
+    """Track-selection criteria shared by all commands."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -42,31 +50,20 @@ class FilterArgs(BaseModel):
     match_all: bool = False
 
 
-class ConfirmationArgs(BaseModel):
-    """How the user gates a side effect before it lands.
+# ── Command args ──────────────────────────────────────────────────────────
 
-    `dry_run` skips the change entirely. `yes` skips confirmation and applies
-    the batch. `interactive` prompts per item. With all three false, the
-    caller is expected to prompt once for the batch.
+
+class SearchArgs(FilterArgs):
+    """Inputs for search().
+
+    Currently equivalent to FilterArgs. Kept as a distinct type so the public
+    signature reads `search(db, SearchArgs)` and so search-specific fields
+    can be added later without changing the call surface.
     """
 
-    model_config = ConfigDict(extra="forbid")
 
-    dry_run: bool = False
-    yes: bool = False
-    interactive: bool = False
-
-
-class EditArgs(BaseModel):
-    """Edit-command inputs that describe what to change.
-
-    `field` names a column from `FIELD_COLUMNS` in `api/edit.py`.
-    `match_pattern` is the optional substring to find within the current value;
-    when omitted, the whole value is replaced. `multi` allows the edit to
-    apply to more than one matched track.
-    """
-
-    model_config = ConfigDict(extra="forbid")
+class EditArgs(FilterArgs):
+    """Inputs for edit()."""
 
     field: str
     replace_value: str
@@ -74,30 +71,25 @@ class EditArgs(BaseModel):
     multi: bool = False
 
 
-class ConvertArgs(BaseModel):
-    """Convert-command inputs that describe the output and conflict policy.
+class ConvertArgs(FilterArgs):
+    """Inputs for convert().
 
-    `delete` is tri-state: `None` defers to a per-format default in
-    `plan_convert`, while `True` / `False` are explicit.
+    `delete` is tri-state: None defers to a per-format default in convert()
+    (True for lossless, False for MP3).
     """
-
-    model_config = ConfigDict(extra="forbid")
 
     format_out: str = "aiff"
     delete: bool | None = None
     overwrite: bool = False
 
 
+# ── Domain types ──────────────────────────────────────────────────────────
+
+
 class Track(BaseModel):
-    """Domain model for a Rekordbox track.
+    """A Rekordbox track. Field names mirror DjmdContent column names.
 
-    Field names mirror DjmdContent column names so conversion is a mechanical
-    field copy with no translation. This type is the sole return type of the
-    API layer — ORM objects never cross the API boundary.
-
-    `extra="allow"` lets `_track_from_content` bulk-copy every DjmdContent
-    column without enumerating each one; the declared fields below stay typed
-    and validated, undeclared columns ride along as untyped attributes.
+    `extra="allow"` lets undeclared columns ride along as untyped attributes.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -125,22 +117,80 @@ class Track(BaseModel):
     TrackNo: int | None = None
 
 
-class EditPlanArgs(FilterArgs, EditArgs):
-    """Inputs for `plan_edit`: filter criteria plus edit specification."""
+SkipReason: TypeAlias = Literal[
+    "no_change", "already_target_format", "output_file_exists"
+]
 
 
-class ConvertPlanArgs(FilterArgs, ConvertArgs):
-    """Inputs for `plan_convert`: filter criteria plus conversion specification."""
+class SkippedTrack(BaseModel):
+    """A track the command declined to operate on."""
+
+    id: str
+    reason: SkipReason
 
 
-class EditCommandArgs(EditPlanArgs, ConfirmationArgs):
-    """All inputs the edit CLI command accepts.
+class EditOp(BaseModel):
+    """A planned or performed edit: track ID + the value it would / did become."""
 
-    Inherits via Pydantic model inheritance: every field of every parent
-    appears flat in this model. An `EditCommandArgs` can be passed anywhere
-    an `EditPlanArgs` or `FilterArgs` is expected.
-    """
+    id: str
+    new_value: str
 
 
-class ConvertCommandArgs(ConvertPlanArgs, ConfirmationArgs):
-    """All inputs the convert CLI command accepts."""
+class ConvertOp(BaseModel):
+    """A planned or performed conversion: track ID + source/output paths."""
+
+    id: str
+    source_path: str
+    output_path: str
+
+
+# ── Response envelopes ────────────────────────────────────────────────────
+
+
+class SearchResponse(BaseModel):
+    tracks: list[Track]
+
+
+class EditResult(BaseModel):
+    """Result payload for edit(). `edits` aligns 1:1 with response.tracks."""
+
+    field: str
+    edits: list[EditOp]
+    skipped: list[SkippedTrack]
+
+
+class EditResponse(BaseModel):
+    tracks: list[Track]
+    result: EditResult
+
+    @model_validator(mode="after")
+    def _check_edit_alignment(self) -> "EditResponse":
+        if len(self.tracks) != len(self.result.edits):
+            raise ValueError(
+                f"tracks ({len(self.tracks)}) and result.edits "
+                f"({len(self.result.edits)}) must align 1:1"
+            )
+        return self
+
+
+class ConvertResult(BaseModel):
+    """Result payload for convert(). `converted` aligns 1:1 with response.tracks."""
+
+    format_out: str
+    converted: list[ConvertOp]
+    deleted: int
+    skipped: list[SkippedTrack]
+
+
+class ConvertResponse(BaseModel):
+    tracks: list[Track]
+    result: ConvertResult
+
+    @model_validator(mode="after")
+    def _check_convert_alignment(self) -> "ConvertResponse":
+        if len(self.tracks) != len(self.result.converted):
+            raise ValueError(
+                f"tracks ({len(self.tracks)}) and result.converted "
+                f"({len(self.result.converted)}) must align 1:1"
+            )
+        return self

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -5,13 +5,13 @@ import pytest
 
 from rekordbox_edit.api.convert import (
     _classify_convert,
-    cleanup_converted_files,
+    _cleanup_converted_files,
+    _convert_to_lossless,
+    _convert_to_mp3,
+    _get_output_path,
+    _rollback_and_cleanup,
+    _update_database_record,
     convert,
-    convert_to_lossless,
-    convert_to_mp3,
-    get_output_path,
-    rollback_and_cleanup,
-    update_database_record,
 )
 from rekordbox_edit.models import (
     ConvertArgs,
@@ -48,7 +48,7 @@ class TestClassifyConvert:
         assert result.reason == "already_target_format"
 
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     def test_skips_output_conflict_when_no_overwrite(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
@@ -67,7 +67,7 @@ class TestClassifyConvert:
         assert result.reason == "output_file_exists"
 
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     def test_overwrite_allows_conflict(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
@@ -87,7 +87,7 @@ class TestClassifyConvert:
         assert result.output_path == "/out.aif"
 
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     def test_returns_convert_op_with_paths(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
@@ -122,7 +122,7 @@ def _seed_filter(mock_gfc, *contents):
 class TestConvertDryRun:
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_returns_response_without_commit(
@@ -195,11 +195,11 @@ class TestConvertRealRun:
         assert response.tracks == []
         mock_db.session.commit.assert_not_called()
 
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_successful_lossless_commits(
@@ -234,11 +234,11 @@ class TestConvertRealRun:
         assert response.tracks[0].ID == "1"
 
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_deletes_originals_when_should_delete_true(
@@ -269,11 +269,11 @@ class TestConvertRealRun:
         mock_remove.assert_called_once_with("/in.wav")
         assert response.result.deleted == 1
 
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=False)
+    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=False)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_conversion_failure_triggers_rollback_and_raises(
@@ -300,13 +300,13 @@ class TestConvertRealRun:
 
         mock_rollback.assert_called_once()
 
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_post_commit_interrupt_does_not_trigger_cleanup(
@@ -324,7 +324,7 @@ class TestConvertRealRun:
         make_djmd_content_item,
     ):
         # commit succeeds; KeyboardInterrupt in the delete-originals loop must
-        # NOT cause cleanup_converted_files to run (output already committed).
+        # NOT cause _cleanup_converted_files to run (output already committed).
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
@@ -341,11 +341,11 @@ class TestConvertRealRun:
         mock_db.session.commit.assert_called_once()
         mock_rollback.assert_not_called()
 
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_preserves_op_order_in_response_tracks(
@@ -363,7 +363,7 @@ class TestConvertRealRun:
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
-        # get_output_path is called twice per content; just return matching paths
+        # _get_output_path is called twice per content; just return matching paths
         mock_get_output.side_effect = lambda content, fmt: (
             f"/{content.ID}.aif",
             f"{content.ID}.aif",
@@ -385,11 +385,11 @@ class TestConvertRealRun:
         assert [op.id for op in response.result.converted] == ["A", "B", "C"]
         assert [t.ID for t in response.tracks] == ["A", "B", "C"]
 
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_post_commit_requery_failure_falls_back_to_pre_mutation(
@@ -428,7 +428,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
     def test_real_run_skips_when_output_exists_without_overwrite(
@@ -476,7 +476,7 @@ class TestConvertToLossless:
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
+        result = _convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
 
         assert result is True
         mock_input.output.assert_called_once_with(
@@ -486,7 +486,7 @@ class TestConvertToLossless:
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_ffmpeg_not_found_raises(self, _):
         with pytest.raises(Exception, match="FFmpeg not found in PATH"):
-            convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+            _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
 
 
 class TestConvertToMp3:
@@ -500,7 +500,7 @@ class TestConvertToMp3:
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = convert_to_mp3("in.flac", "out.mp3")
+        result = _convert_to_mp3("in.flac", "out.mp3")
 
         assert result is True
 
@@ -513,7 +513,7 @@ class TestUpdateDatabaseRecord:
         mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {"bitrate": 1000, "bit_depth": 24}
 
-        update_database_record(mock_db, 123, "output.flac", "/path/to", "FLAC")
+        _update_database_record(mock_db, 123, "output.flac", "/path/to", "FLAC")
 
         assert mock_content.FileNameL == "output.flac"
         assert mock_content.FolderPath == "/path/to/output.flac"
@@ -527,23 +527,23 @@ class TestCleanupConvertedFiles:
             ConvertOp(id="1", source_path="/s1", output_path="/p/f1.aiff"),
             ConvertOp(id="2", source_path="/s2", output_path="/p/f2.aiff"),
         ]
-        cleanup_converted_files(ops)
+        _cleanup_converted_files(ops)
         assert mock_remove.call_count == 2
 
     @patch("os.remove", side_effect=OSError)
     def test_oserror_is_swallowed(self, _):
-        cleanup_converted_files(
+        _cleanup_converted_files(
             [ConvertOp(id="1", source_path="/s", output_path="/p/f.aiff")]
         )
 
 
 class TestRollbackAndCleanup:
     def test_rolls_back_session(self, mock_db):
-        rollback_and_cleanup(mock_db, [])
+        _rollback_and_cleanup(mock_db, [])
         mock_db.session.rollback.assert_called_once()
 
     def test_no_db_is_noop(self):
-        rollback_and_cleanup(None, [])
+        _rollback_and_cleanup(None, [])
 
 
 class TestGetOutputPath:
@@ -552,7 +552,7 @@ class TestGetOutputPath:
             FileNameL="song.flac", FolderPath="/music/folder/song.flac"
         )
 
-        output_path, output_filename, src_dirname = get_output_path(content, "aiff")
+        output_path, output_filename, src_dirname = _get_output_path(content, "aiff")
 
         assert output_path == os.path.normpath("/music/folder/song.aiff")
         assert output_filename == "song.aiff"

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -498,7 +498,8 @@ class TestRollbackAndCleanup:
 class TestConvert:
     def _make_plan(self, files=None, format_out="aiff", should_delete=True):
         return ConvertPlan(
-            files=files or [Track(ID="1", FileNameL="track.wav")],
+            files=files
+            or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
             skipped=[],
             should_delete=should_delete,
             format_out=format_out,

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -385,6 +385,47 @@ class TestConvertRealRun:
         assert [op.id for op in response.result.converted] == ["A", "B", "C"]
         assert [t.ID for t in response.tracks] == ["A", "B", "C"]
 
+    @patch("rekordbox_edit.api.convert.update_database_record")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_post_commit_requery_failure_falls_back_to_pre_mutation(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_update,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        # Mock the post-commit select to raise
+        mock_db.session.execute.side_effect = RuntimeError("post-commit query failed")
+
+        response = convert(
+            mock_db, ConvertArgs(format_out="aiff", delete=False, overwrite=True)
+        )
+
+        # Commit happened
+        mock_db.session.commit.assert_called_once()
+        # Response built successfully (no ValidationError raised)
+        assert len(response.result.converted) == 1
+        assert response.result.converted[0].id == "1"
+        # tracks came from the pre-commit fallback
+        assert len(response.tracks) == 1
+        assert response.tracks[0].ID == "1"
+
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.api.convert.get_output_path")

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import Mock, patch
 
+import ffmpeg
 import pytest
 
 from rekordbox_edit.api.convert import (
@@ -456,6 +457,136 @@ class TestConvertRealRun:
         assert response.result.skipped[0].reason == "output_file_exists"
         mock_db.session.commit.assert_not_called()
 
+    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_missing_source_triggers_rollback_and_raises(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_rollback,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+
+        with pytest.raises(RuntimeError, match="Source not found"):
+            convert(mock_db, ConvertArgs(format_out="aiff", overwrite=True))
+        mock_rollback.assert_called_once()
+
+    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch(
+        "rekordbox_edit.api.convert._update_database_record",
+        side_effect=RuntimeError("DB error"),
+    )
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_db_update_exception_triggers_rollback_and_reraises(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _lossless,
+        _update,
+        mock_rollback,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+
+        with pytest.raises(RuntimeError, match="DB error"):
+            convert(mock_db, ConvertArgs(format_out="aiff", overwrite=True))
+        mock_rollback.assert_called_once()
+
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_mp3", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_mp3_format_uses_convert_to_mp3(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_mp3,
+        _update,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.mp3", "out.mp3", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        convert(mock_db, ConvertArgs(format_out="mp3", overwrite=True))
+
+        mock_mp3.assert_called_once_with("/in.wav", "/out.mp3")
+
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_skips_deletion_when_should_delete_false(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _lossless,
+        _update,
+        mock_remove,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(
+            mock_db, ConvertArgs(format_out="aiff", delete=False, overwrite=True)
+        )
+
+        mock_remove.assert_not_called()
+        assert response.result.deleted == 0
+
 
 # ── Helper-function tests (preserved from existing file) ──────────────────
 
@@ -488,6 +619,105 @@ class TestConvertToLossless:
         with pytest.raises(Exception, match="FFmpeg not found in PATH"):
             _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
 
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 24})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_convert_to_wav_24bit(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        result = _convert_to_lossless("in.flac", "out.wav", OutputFormats.WAV)
+
+        assert result is True
+        mock_ffmpeg.input.return_value.output.assert_called_once_with(
+            "out.wav", acodec="pcm_s24le", map_metadata=0, write_id3v2=1
+        )
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 24})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_convert_to_flac(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        result = _convert_to_lossless("in.wav", "out.flac", OutputFormats.FLAC)
+
+        assert result is True
+        mock_ffmpeg.input.return_value.output.assert_called_once_with(
+            "out.flac", acodec="flac", map_metadata=0, write_id3v2=1
+        )
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_unsupported_format_raises(self, _ffmpeg_in_path, _audio):
+        fake_format = Mock()
+        fake_format.value = "xyz"
+        with pytest.raises(Exception, match="Unsupported lossless format"):
+            _convert_to_lossless("in.flac", "out.xyz", fake_format)
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 8})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_unknown_bit_depth_falls_back_to_first_codec(
+        self, mock_ffmpeg, _ffmpeg_in_path, _audio
+    ):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+
+        assert result is True
+        # First codec in {16: pcm_s16be, ...} for AIFF.
+        mock_ffmpeg.input.return_value.output.assert_called_once_with(
+            "out.aiff", acodec="pcm_s16be", map_metadata=0, write_id3v2=1
+        )
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", b"stderr")
+
+        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+
+        assert result is False
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_ffmpeg_error_no_stderr_returns_false(
+        self, mock_ffmpeg, _ffmpeg_in_path, _audio
+    ):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", None)
+
+        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+
+        assert result is False
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_unexpected_exception_reraises(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = RuntimeError("disk full")
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+
 
 class TestConvertToMp3:
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -504,6 +734,46 @@ class TestConvertToMp3:
 
         assert result is True
 
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
+    def test_ffmpeg_not_found_raises(self, _):
+        with pytest.raises(Exception, match="FFmpeg not found in PATH"):
+            _convert_to_mp3("in.flac", "out.mp3")
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, _):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", b"stderr")
+
+        result = _convert_to_mp3("in.flac", "out.mp3")
+
+        assert result is False
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_ffmpeg_error_no_stderr_returns_false(self, mock_ffmpeg, _):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", None)
+
+        result = _convert_to_mp3("in.flac", "out.mp3")
+
+        assert result is False
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_unexpected_exception_reraises(self, mock_ffmpeg, _):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.side_effect = RuntimeError("permission denied")
+
+        with pytest.raises(RuntimeError, match="permission denied"):
+            _convert_to_mp3("in.flac", "out.mp3")
+
 
 class TestUpdateDatabaseRecord:
     @patch("rekordbox_edit.api.convert.get_audio_info")
@@ -518,6 +788,39 @@ class TestUpdateDatabaseRecord:
         assert mock_content.FileNameL == "output.flac"
         assert mock_content.FolderPath == "/path/to/output.flac"
         assert mock_content.BitRate == 0
+
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_mp3_sets_bitrate_from_probe(
+        self, mock_get_audio_info, make_djmd_content_item
+    ):
+        mock_db = Mock()
+        mock_content = make_djmd_content_item(ID=123)
+        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
+        mock_get_audio_info.return_value = {"bitrate": 320, "bit_depth": 16}
+
+        _update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
+
+        assert mock_content.BitRate == 320
+
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_mp3_none_bitrate_defaults_to_320(
+        self, mock_get_audio_info, make_djmd_content_item
+    ):
+        mock_db = Mock()
+        mock_content = make_djmd_content_item(ID=123)
+        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
+        mock_get_audio_info.return_value = {"bitrate": None, "bit_depth": 16}
+
+        _update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
+
+        assert mock_content.BitRate == 320
+
+    def test_content_not_found_raises(self):
+        mock_db = Mock()
+        mock_db.get_content().filter_by(ID=123).first.return_value = None
+
+        with pytest.raises(Exception, match="Content record with ID 123 not found"):
+            _update_database_record(mock_db, 123, "output.flac", "/path/to", "FLAC")
 
 
 class TestCleanupConvertedFiles:
@@ -545,6 +848,31 @@ class TestRollbackAndCleanup:
     def test_no_db_is_noop(self):
         _rollback_and_cleanup(None, [])
 
+    def test_no_session_is_noop(self):
+        db = Mock()
+        db.session = None
+        _rollback_and_cleanup(db, [])
+
+    @patch("rekordbox_edit.api.convert._cleanup_converted_files")
+    def test_cleans_up_converted_files(self, mock_cleanup, mock_db):
+        ops = [ConvertOp(id="1", source_path="/s", output_path="/p/f.aiff")]
+        _rollback_and_cleanup(mock_db, ops)
+        mock_cleanup.assert_called_once_with(ops)
+
+    @patch("rekordbox_edit.api.convert._cleanup_converted_files")
+    def test_skips_cleanup_when_no_converted_files(self, mock_cleanup, mock_db):
+        _rollback_and_cleanup(mock_db, [])
+        mock_cleanup.assert_not_called()
+
+    @patch("rekordbox_edit.api.convert.logger")
+    def test_rollback_exception_logs_critical_and_reraises(self, mock_logger, mock_db):
+        mock_db.session.rollback.side_effect = Exception("DB connection lost")
+
+        with pytest.raises(Exception, match="DB connection lost"):
+            _rollback_and_cleanup(mock_db, [])
+
+        assert mock_logger.critical.call_count == 2
+
 
 class TestGetOutputPath:
     def test_basic_path(self, make_djmd_content_item):
@@ -557,3 +885,13 @@ class TestGetOutputPath:
         assert output_path == os.path.normpath("/music/folder/song.aiff")
         assert output_filename == "song.aiff"
         assert src_dirname == os.path.normpath("/music/folder")
+
+    def test_mp3_extension(self, make_djmd_content_item):
+        content = make_djmd_content_item(
+            FileNameL="song.flac", FolderPath="/music/folder/song.flac"
+        )
+
+        output_path, output_filename, _ = _get_output_path(content, "mp3")
+
+        assert output_path == os.path.normpath("/music/folder/song.mp3")
+        assert output_filename == "song.mp3"

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1,115 +1,422 @@
 import os
 from unittest.mock import Mock, patch
 
-import ffmpeg
 import pytest
 
 from rekordbox_edit.api.convert import (
+    _classify_convert,
     cleanup_converted_files,
     convert,
     convert_to_lossless,
     convert_to_mp3,
     get_output_path,
-    plan_convert,
     rollback_and_cleanup,
     update_database_record,
-    ConvertPlan,
-    ConvertResult,
 )
-from rekordbox_edit.models import ConvertPlanArgs, Track
+from rekordbox_edit.models import (
+    ConvertArgs,
+    ConvertOp,
+    ConvertResponse,
+    SkippedTrack,
+)
 from rekordbox_edit.utils import OutputFormats
 
 
-class TestPlanConvert:
-    @patch("rekordbox_edit.api.convert.get_filtered_content")
+class TestClassifyConvert:
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_filters_already_converted_tracks(
-        self, mock_get_type, mock_gfc, mock_db, make_djmd_content_item
-    ):
+    def test_skips_already_target_format(self, mock_get_type, make_djmd_content_item):
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
-        content = make_djmd_content_item(FileType=1)  # already AIFF
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content]
-        mock_gfc.return_value = mock_result
+        content = make_djmd_content_item(ID="1", FileType=1)  # already AIFF
 
-        plan = plan_convert(mock_db, ConvertPlanArgs(format_out="aiff"))
+        result = _classify_convert(content, ConvertArgs(format_out="aiff"))
 
-        assert plan.files == []
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "already_target_format"
 
-    @patch("rekordbox_edit.api.convert.get_filtered_content")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_skips_lossy_formats(
-        self, mock_get_type, mock_gfc, mock_db, make_djmd_content_item
-    ):
+    def test_skips_lossy_formats(self, mock_get_type, make_djmd_content_item):
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
-        mp3_content = make_djmd_content_item(FileType=5)  # MP3 — skip
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [mp3_content]
-        mock_gfc.return_value = mock_result
+        content = make_djmd_content_item(ID="2", FileType=5)  # MP3
 
-        plan = plan_convert(mock_db, ConvertPlanArgs(format_out="aiff"))
+        result = _classify_convert(content, ConvertArgs(format_out="aiff"))
 
-        assert plan.files == []
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "already_target_format"
 
-    @patch("rekordbox_edit.api.convert.os.path.exists")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.api.convert.get_output_path")
-    @patch("rekordbox_edit.api.convert.get_filtered_content")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_skips_conflicts_when_no_overwrite(
+    def test_skips_output_conflict_when_no_overwrite(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="3", FileType=11)  # WAV
+
+        result = _classify_convert(
+            content, ConvertArgs(format_out="aiff", overwrite=False)
+        )
+
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "output_file_exists"
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_overwrite_allows_conflict(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="3", FileType=11, FolderPath="/in.wav")
+
+        result = _classify_convert(
+            content, ConvertArgs(format_out="aiff", overwrite=True)
+        )
+
+        assert isinstance(result, ConvertOp)
+        assert result.source_path == "/in.wav"
+        assert result.output_path == "/out.aif"
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_returns_convert_op_with_paths(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/music/song.aif", "song.aif", "/music")
+        content = make_djmd_content_item(
+            ID="4", FileType=11, FolderPath="/music/song.wav"
+        )
+
+        result = _classify_convert(content, ConvertArgs(format_out="aiff"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.id == "4"
+        assert result.source_path == "/music/song.wav"
+        assert result.output_path == "/music/song.aif"
+
+
+def _seed_db(mock_db, *contents):
+    """Make mock_db.session.execute(select).scalars().all() return contents."""
+    mock_db.session.execute.return_value.scalars.return_value.all.return_value = list(
+        contents
+    )
+
+
+def _seed_filter(mock_gfc, *contents):
+    mock_gfc.return_value.scalars.return_value.all.return_value = list(contents)
+
+
+class TestConvertDryRun:
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_returns_response_without_commit(
         self,
-        mock_get_type,
         mock_gfc,
+        mock_get_type,
         mock_get_output,
         mock_exists,
+        _ffmpeg,
         mock_db,
         make_djmd_content_item,
     ):
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
-        content = make_djmd_content_item(FileType=11)  # WAV → convert to AIFF
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content]
-        mock_gfc.return_value = mock_result
-        mock_get_output.return_value = ("/path/output.aif", "output.aif", "/path")
-        mock_exists.return_value = True  # output already exists
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
 
-        plan = plan_convert(
-            mock_db, ConvertPlanArgs(format_out="aiff", overwrite=False)
+        response = convert(mock_db, ConvertArgs(format_out="aiff"), dry_run=True)
+
+        assert isinstance(response, ConvertResponse)
+        assert response.result.format_out == "aiff"
+        assert len(response.result.converted) == 1
+        assert response.result.deleted == 0
+        assert response.tracks[0].ID == "1"
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_dry_run_surfaces_skipped(
+        self,
+        mock_gfc,
+        mock_get_type,
+        _ffmpeg,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        content = make_djmd_content_item(ID="1", FileType=1)  # already AIFF
+        _seed_filter(mock_gfc, content)
+
+        response = convert(mock_db, ConvertArgs(format_out="aiff"), dry_run=True)
+
+        assert response.result.converted == []
+        assert response.tracks == []
+        assert len(response.result.skipped) == 1
+        assert response.result.skipped[0].reason == "already_target_format"
+
+
+class TestConvertRealRun:
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
+    def test_no_ffmpeg_raises_immediately(self, _, mock_db):
+        with pytest.raises(RuntimeError, match="FFmpeg"):
+            convert(mock_db, ConvertArgs(format_out="aiff"))
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_no_matching_tracks_returns_empty_response(
+        self, mock_gfc, _ffmpeg, mock_db
+    ):
+        _seed_filter(mock_gfc)
+
+        response = convert(mock_db, ConvertArgs(format_out="aiff"))
+
+        assert response.result.converted == []
+        assert response.tracks == []
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.api.convert.update_database_record")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_successful_lossless_commits(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_update,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)  # post-commit re-query returns the same row
+
+        response = convert(
+            mock_db, ConvertArgs(format_out="aiff", delete=False, overwrite=True)
         )
 
-        assert plan.files == []
-        assert len(plan.skipped) == 1
+        mock_lossless.assert_called_once_with("/in.wav", "/out.aif", OutputFormats.AIFF)
+        mock_update.assert_called_once()
+        mock_db.session.commit.assert_called_once()
+        assert response.result.converted[0].id == "1"
+        assert response.result.deleted == 0
+        assert response.tracks[0].ID == "1"
 
-    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert.update_database_record")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_should_delete_defaults_true_for_lossless(
-        self, mock_get_type, mock_gfc, mock_db
-    ):
-        mock_get_type.return_value = 99
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_gfc.return_value = mock_result
-
-        plan = plan_convert(mock_db, ConvertPlanArgs(format_out="aiff"))
-        assert plan.should_delete is True
-
     @patch("rekordbox_edit.api.convert.get_filtered_content")
-    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_should_delete_defaults_false_for_mp3(
-        self, mock_get_type, mock_gfc, mock_db
+    def test_deletes_originals_when_should_delete_true(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_update,
+        mock_remove,
+        mock_db,
+        make_djmd_content_item,
     ):
-        mock_get_type.return_value = 99
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_gfc.return_value = mock_result
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
 
-        plan = plan_convert(mock_db, ConvertPlanArgs(format_out="mp3"))
-        assert plan.should_delete is False
+        response = convert(
+            mock_db, ConvertArgs(format_out="aiff", delete=True, overwrite=True)
+        )
+
+        mock_remove.assert_called_once_with("/in.wav")
+        assert response.result.deleted == 1
+
+    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=False)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_conversion_failure_triggers_rollback_and_raises(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_rollback,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+
+        with pytest.raises(RuntimeError, match="Conversion failed"):
+            convert(mock_db, ConvertArgs(format_out="aiff", overwrite=True))
+
+        mock_rollback.assert_called_once()
+
+    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
+    @patch("rekordbox_edit.api.convert.update_database_record")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_post_commit_interrupt_does_not_trigger_cleanup(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_update,
+        _remove,
+        mock_rollback,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # commit succeeds; KeyboardInterrupt in the delete-originals loop must
+        # NOT cause cleanup_converted_files to run (output already committed).
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        with pytest.raises(KeyboardInterrupt):
+            convert(
+                mock_db, ConvertArgs(format_out="aiff", delete=True, overwrite=True)
+            )
+
+        mock_db.session.commit.assert_called_once()
+        mock_rollback.assert_not_called()
+
+    @patch("rekordbox_edit.api.convert.update_database_record")
+    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_preserves_op_order_in_response_tracks(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_lossless,
+        mock_update,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        # get_output_path is called twice per content; just return matching paths
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        contents = [
+            make_djmd_content_item(ID="A", FileType=11, FolderPath="/A.wav"),
+            make_djmd_content_item(ID="B", FileType=11, FolderPath="/B.wav"),
+            make_djmd_content_item(ID="C", FileType=11, FolderPath="/C.wav"),
+        ]
+        _seed_filter(mock_gfc, *contents)
+        # Post-commit re-query returns in scrambled order
+        _seed_db(mock_db, contents[2], contents[0], contents[1])
+
+        response = convert(
+            mock_db, ConvertArgs(format_out="aiff", delete=False, overwrite=True)
+        )
+
+        assert [op.id for op in response.result.converted] == ["A", "B", "C"]
+        assert [t.ID for t in response.tracks] == ["A", "B", "C"]
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_real_run_skips_when_output_exists_without_overwrite(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        mock_exists,
+        _ffmpeg,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+
+        # Default overwrite=False with output path existing -> classifier should skip.
+        response = convert(mock_db, ConvertArgs(format_out="aiff"))
+
+        assert response.result.converted == []
+        assert len(response.result.skipped) == 1
+        assert response.result.skipped[0].reason == "output_file_exists"
+        mock_db.session.commit.assert_not_called()
+
+
+# ── Helper-function tests (preserved from existing file) ──────────────────
 
 
 class TestConvertToLossless:
@@ -131,161 +438,20 @@ class TestConvertToLossless:
         result = convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
 
         assert result is True
-        mock_get_audio_info.assert_called_once_with("input.flac")
-        mock_ffmpeg.input.assert_called_once_with("input.flac")
         mock_input.output.assert_called_once_with(
             "output.aiff", acodec="pcm_s16be", map_metadata=0, write_id3v2=1
         )
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_to_wav_24bit(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 24}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.return_value = None
-
-        result = convert_to_lossless("input.flac", "output.wav", OutputFormats.WAV)
-
-        assert result is True
-        mock_input.output.assert_called_once_with(
-            "output.wav", acodec="pcm_s24le", map_metadata=0, write_id3v2=1
-        )
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_to_flac(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 24}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.return_value = None
-
-        result = convert_to_lossless("input.wav", "output.flac", OutputFormats.FLAC)
-
-        assert result is True
-        mock_input.output.assert_called_once_with(
-            "output.flac", acodec="flac", map_metadata=0, write_id3v2=1
-        )
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    def test_convert_unsupported_format_raises(
-        self, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 16}
-
-        fake_format = Mock()
-        fake_format.value = "xyz"
-
-        with pytest.raises(Exception, match="Unsupported lossless format"):
-            convert_to_lossless("input.flac", "output.xyz", fake_format)
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_ffmpeg_error_returns_false(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 16}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", "stdout", "stderr")
-
-        result = convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
-
-        assert result is False
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    def test_ffmpeg_not_found_raises(self, mock_ffmpeg_in_path):
-        mock_ffmpeg_in_path.return_value = False
-
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
+    def test_ffmpeg_not_found_raises(self, _):
         with pytest.raises(Exception, match="FFmpeg not found in PATH"):
-            convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unknown_bit_depth_falls_back_to_first_codec(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 8}  # not in {16, 24, 32}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.return_value = None
-
-        result = convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
-
-        assert result is True
-        mock_input.output.assert_called_once_with(
-            "output.aiff", acodec="pcm_s16be", map_metadata=0, write_id3v2=1
-        )
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_no_stderr_returns_false(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 16}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", "stdout", None)
-
-        result = convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
-
-        assert result is False
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unexpected_exception_reraises(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 16}
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = RuntimeError("disk full")
-
-        with pytest.raises(RuntimeError, match="disk full"):
-            convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
+            convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
 
 
 class TestConvertToMp3:
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_success(self, mock_ffmpeg, mock_ffmpeg_in_path):
-        mock_ffmpeg_in_path.return_value = True
+    def test_success(self, mock_ffmpeg, _):
         mock_input = Mock()
         mock_output = Mock()
         mock_ffmpeg.input.return_value = mock_input
@@ -293,70 +459,9 @@ class TestConvertToMp3:
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = convert_to_mp3("input.flac", "output.mp3")
+        result = convert_to_mp3("in.flac", "out.mp3")
 
         assert result is True
-        mock_ffmpeg.input.assert_called_once_with("input.flac")
-        mock_input.output.assert_called_once_with(
-            "output.mp3",
-            acodec="libmp3lame",
-            audio_bitrate="320k",
-            map_metadata=0,
-            write_id3v2=1,
-        )
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, mock_ffmpeg_in_path):
-        mock_ffmpeg_in_path.return_value = True
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", "stdout", "stderr")
-
-        result = convert_to_mp3("input.flac", "output.mp3")
-
-        assert result is False
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    def test_ffmpeg_not_found_raises(self, mock_ffmpeg_in_path):
-        mock_ffmpeg_in_path.return_value = False
-
-        with pytest.raises(Exception, match="FFmpeg not found in PATH"):
-            convert_to_mp3("input.flac", "output.mp3")
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_no_stderr_returns_false(
-        self, mock_ffmpeg, mock_ffmpeg_in_path
-    ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", "stdout", None)
-
-        result = convert_to_mp3("input.flac", "output.mp3")
-
-        assert result is False
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unexpected_exception_reraises(self, mock_ffmpeg, mock_ffmpeg_in_path):
-        mock_ffmpeg_in_path.return_value = True
-        mock_input = Mock()
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value = mock_input
-        mock_input.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = RuntimeError("permission denied")
-
-        with pytest.raises(RuntimeError, match="permission denied"):
-            convert_to_mp3("input.flac", "output.mp3")
 
 
 class TestUpdateDatabaseRecord:
@@ -371,94 +476,24 @@ class TestUpdateDatabaseRecord:
 
         assert mock_content.FileNameL == "output.flac"
         assert mock_content.FolderPath == "/path/to/output.flac"
-        assert mock_content.FileType == 5  # FLAC
         assert mock_content.BitRate == 0
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_mp3_sets_bitrate_from_probe(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_db = Mock()
-        mock_content = make_djmd_content_item(ID=123)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": 320, "bit_depth": 16}
-
-        update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
-
-        assert mock_content.FileNameL == "output.mp3"
-        assert mock_content.FolderPath == "/path/to/output.mp3"
-        assert mock_content.FileType == 1  # MP3
-        assert mock_content.BitRate == 320
-
-    def test_content_not_found_raises(self):
-        mock_db = Mock()
-        mock_db.get_content().filter_by(ID=123).first.return_value = None
-
-        with pytest.raises(Exception, match="Content record with ID 123 not found"):
-            update_database_record(mock_db, 123, "output.flac", "/path/to", "FLAC")
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_bit_depth_mismatch_raises(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_db = Mock()
-        mock_content = make_djmd_content_item(ID=123, BitDepth=16)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": 1000, "bit_depth": 24}
-
-        with pytest.raises(Exception, match="Bit depth mismatch"):
-            update_database_record(mock_db, 123, "output.aiff", "/path/to", "AIFF")
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_mp3_none_bitrate_defaults_to_320(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_db = Mock()
-        mock_content = make_djmd_content_item(ID=123)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": None, "bit_depth": 16}
-
-        update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
-
-        assert mock_content.BitRate == 320
-
-    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_unsupported_format_raises(
-        self, mock_get_audio_info, mock_get_file_type, make_djmd_content_item
-    ):
-        mock_db = Mock()
-        mock_content = make_djmd_content_item(ID=123)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": 1000, "bit_depth": 16}
-        mock_get_file_type.return_value = None
-
-        with pytest.raises(Exception, match="Unsupported output format"):
-            update_database_record(mock_db, 123, "output.xyz", "/path/to", "XYZ")
 
 
 class TestCleanupConvertedFiles:
     @patch("os.remove")
     def test_removes_all_output_files(self, mock_remove):
-        converted_files = [
-            {"output_path": "/path/file1.aiff"},
-            {"output_path": "/path/file2.aiff"},
+        ops = [
+            ConvertOp(id="1", source_path="/s1", output_path="/p/f1.aiff"),
+            ConvertOp(id="2", source_path="/s2", output_path="/p/f2.aiff"),
         ]
-
-        cleanup_converted_files(converted_files)
-
+        cleanup_converted_files(ops)
         assert mock_remove.call_count == 2
-        mock_remove.assert_any_call("/path/file1.aiff")
-        mock_remove.assert_any_call("/path/file2.aiff")
 
-    @patch("os.remove")
-    def test_oserror_is_swallowed(self, mock_remove):
-        converted_files = [{"output_path": "/path/file1.aiff"}]
-        mock_remove.side_effect = OSError("Permission denied")
-
-        cleanup_converted_files(converted_files)  # must not raise
-
-        mock_remove.assert_called_once_with("/path/file1.aiff")
+    @patch("os.remove", side_effect=OSError)
+    def test_oserror_is_swallowed(self, _):
+        cleanup_converted_files(
+            [ConvertOp(id="1", source_path="/s", output_path="/p/f.aiff")]
+        )
 
 
 class TestRollbackAndCleanup:
@@ -467,290 +502,17 @@ class TestRollbackAndCleanup:
         mock_db.session.rollback.assert_called_once()
 
     def test_no_db_is_noop(self):
-        rollback_and_cleanup(None, [])  # must not raise
-
-    def test_no_session_is_noop(self):
-        db = Mock()
-        db.session = None
-        rollback_and_cleanup(db, [])  # must not raise
-
-    @patch("rekordbox_edit.api.convert.cleanup_converted_files")
-    def test_cleans_up_converted_files(self, mock_cleanup, mock_db):
-        converted_files = [{"output_path": "/path/file.aiff"}]
-        rollback_and_cleanup(mock_db, converted_files)
-        mock_cleanup.assert_called_once_with(converted_files)
-
-    @patch("rekordbox_edit.api.convert.cleanup_converted_files")
-    def test_skips_cleanup_when_no_converted_files(self, mock_cleanup, mock_db):
-        rollback_and_cleanup(mock_db, [])
-        mock_cleanup.assert_not_called()
-
-    @patch("rekordbox_edit.api.convert.logger")
-    def test_rollback_exception_logs_critical_and_reraises(self, mock_logger, mock_db):
-        mock_db.session.rollback.side_effect = Exception("DB connection lost")
-
-        with pytest.raises(Exception, match="DB connection lost"):
-            rollback_and_cleanup(mock_db, [])
-
-        assert mock_logger.critical.call_count == 2
-
-
-class TestConvert:
-    def _make_plan(self, files=None, format_out="aiff", should_delete=True):
-        return ConvertPlan(
-            files=files
-            or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
-            skipped=[],
-            should_delete=should_delete,
-            format_out=format_out,
-        )
-
-    def _seed_db(self, mock_db, *contents):
-        mock_db.session.execute.return_value.scalars.return_value.all.return_value = (
-            list(contents)
-        )
-
-    def test_empty_plan_returns_early_without_commit(self, mock_db):
-        plan = ConvertPlan(files=[], skipped=[], should_delete=True, format_out="aiff")
-        result = convert(mock_db, plan)
-        assert result == ConvertResult(converted=[], deleted=0)
-        mock_db.session.commit.assert_not_called()
-
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
-    def test_no_ffmpeg_raises_immediately(self, _, mock_db):
-        with pytest.raises(RuntimeError, match="FFmpeg"):
-            convert(mock_db, self._make_plan())
-        mock_db.session.commit.assert_not_called()
-
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_missing_source_triggers_rollback_and_raises(
-        self,
-        _,
-        mock_get_output,
-        mock_exists,
-        mock_rollback,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        self._seed_db(mock_db, make_djmd_content_item(ID="1"))
-        with pytest.raises(RuntimeError, match="Source not found"):
-            convert(mock_db, self._make_plan())
-        mock_rollback.assert_called_once()
-
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=False)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_conversion_failure_triggers_rollback_and_raises(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_rollback,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        self._seed_db(mock_db, make_djmd_content_item(ID="1"))
-        with pytest.raises(RuntimeError, match="Conversion failed"):
-            convert(mock_db, self._make_plan())
-        mock_rollback.assert_called_once()
-
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
-    @patch(
-        "rekordbox_edit.api.convert.update_database_record",
-        side_effect=RuntimeError("DB error"),
-    )
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_exception_triggers_rollback_and_reraises(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_update,
-        mock_rollback,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        self._seed_db(mock_db, make_djmd_content_item(ID="1"))
-        with pytest.raises(RuntimeError, match="DB error"):
-            convert(mock_db, self._make_plan())
-        mock_rollback.assert_called_once()
-
-    @patch("rekordbox_edit.api.convert.rollback_and_cleanup")
-    @patch(
-        "rekordbox_edit.api.convert.convert_to_lossless", side_effect=KeyboardInterrupt
-    )
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_keyboard_interrupt_triggers_rollback_and_reraises(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_rollback,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        self._seed_db(mock_db, make_djmd_content_item(ID="1"))
-        with pytest.raises(KeyboardInterrupt):
-            convert(mock_db, self._make_plan())
-        mock_rollback.assert_called_once()
-
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_successful_lossless_commits_and_returns_result(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_update,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        content = make_djmd_content_item(ID="1", FolderPath="/music/track.wav")
-        self._seed_db(mock_db, content)
-
-        result = convert(mock_db, self._make_plan(should_delete=False))
-
-        mock_lossless.assert_called_once()
-        mock_update.assert_called_once()
-        mock_db.session.commit.assert_called_once()
-        assert len(result.converted) == 1
-        assert result.deleted == 0
-
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_mp3", return_value=True)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.mp3", "out.mp3", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_mp3_format_uses_convert_to_mp3(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_mp3,
-        mock_update,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        content = make_djmd_content_item(ID="1", FolderPath="/music/track.wav")
-        self._seed_db(mock_db, content)
-
-        convert(mock_db, self._make_plan(format_out="mp3", should_delete=False))
-
-        mock_mp3.assert_called_once_with(content.FolderPath, "/out.mp3")
-
-    @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_deletes_originals_when_should_delete_true(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_update,
-        mock_remove,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        content = make_djmd_content_item(ID="1", FolderPath="/music/track.wav")
-        self._seed_db(mock_db, content)
-
-        result = convert(mock_db, self._make_plan(should_delete=True))
-
-        mock_remove.assert_called_once_with(content.FolderPath)
-        assert result.deleted == 1
-
-    @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert.update_database_record")
-    @patch("rekordbox_edit.api.convert.convert_to_lossless", return_value=True)
-    @patch(
-        "rekordbox_edit.api.convert.get_output_path",
-        return_value=("/out.aiff", "out.aiff", "/"),
-    )
-    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_skips_deletion_when_should_delete_false(
-        self,
-        _,
-        mock_exists,
-        mock_get_output,
-        mock_lossless,
-        mock_update,
-        mock_remove,
-        mock_db,
-        make_djmd_content_item,
-    ):
-        content = make_djmd_content_item(ID="1", FolderPath="/music/track.wav")
-        self._seed_db(mock_db, content)
-
-        result = convert(mock_db, self._make_plan(should_delete=False))
-
-        mock_remove.assert_not_called()
-        assert result.deleted == 0
+        rollback_and_cleanup(None, [])
 
 
 class TestGetOutputPath:
     def test_basic_path(self, make_djmd_content_item):
         content = make_djmd_content_item(
-            FileNameL="song.flac",
-            FolderPath="/music/folder/song.flac",
+            FileNameL="song.flac", FolderPath="/music/folder/song.flac"
         )
 
         output_path, output_filename, src_dirname = get_output_path(content, "aiff")
 
         assert output_path == os.path.normpath("/music/folder/song.aiff")
         assert output_filename == "song.aiff"
-        assert src_dirname == os.path.normpath("/music/folder")
-
-    def test_mp3_extension(self, make_djmd_content_item):
-        content = make_djmd_content_item(
-            FileNameL="song.flac",
-            FolderPath="/music/folder/song.flac",
-        )
-
-        output_path, output_filename, src_dirname = get_output_path(content, "mp3")
-
-        assert output_path == os.path.normpath("/music/folder/song.mp3")
-        assert output_filename == "song.mp3"
         assert src_dirname == os.path.normpath("/music/folder")

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -1,106 +1,166 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-from rekordbox_edit.api.edit import EditPlan, EditResult, edit, plan_edit
-from rekordbox_edit.models import EditPlanArgs, Track
+from rekordbox_edit.api.edit import _classify_edit, edit
+from rekordbox_edit.models import (
+    EditArgs,
+    EditOp,
+    EditResponse,
+    SkippedTrack,
+)
 
 
-class TestPlanEdit:
-    @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_returns_edit_plan(self, mock_gfc, mock_db, make_djmd_content_item):
+class TestClassifyEdit:
+    def test_returns_edit_op_when_value_would_change(self, make_djmd_content_item):
         content = make_djmd_content_item(ID="1", Title="Old")
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content]
-        mock_gfc.return_value = mock_result
+        args = EditArgs(field="Title", replace_value="New")
 
-        plan = plan_edit(mock_db, EditPlanArgs(field="Title", replace_value="New"))
+        result = _classify_edit(content, args)
 
-        assert isinstance(plan, EditPlan)
-        assert len(plan.edits) == 1
-        track, new_val = plan.edits[0]
-        assert isinstance(track, Track)
-        assert track.ID == "1"
-        assert new_val == "New"
+        assert isinstance(result, EditOp)
+        assert result.id == "1"
+        assert result.new_value == "New"
 
+    def test_returns_skipped_when_value_equals_current(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1", Title="Same")
+        args = EditArgs(field="Title", replace_value="Same")
+
+        result = _classify_edit(content, args)
+
+        assert isinstance(result, SkippedTrack)
+        assert result.id == "1"
+        assert result.reason == "no_change"
+
+    def test_returns_skipped_when_current_is_none(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1", Title=None)
+        args = EditArgs(field="Title", replace_value="New")
+
+        result = _classify_edit(content, args)
+
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "no_change"
+
+    def test_match_pattern_applied(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1", Title="Hello World")
+        args = EditArgs(field="Title", replace_value="Earth", match_pattern="World")
+
+        result = _classify_edit(content, args)
+
+        assert isinstance(result, EditOp)
+        assert result.new_value == "Hello Earth"
+
+
+class TestEditDryRun:
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_skips_tracks_with_no_change(
+    def test_returns_response_without_committing(
         self, mock_gfc, mock_db, make_djmd_content_item
     ):
-        content = make_djmd_content_item(Title="Same")
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content]
-        mock_gfc.return_value = mock_result
+        content = make_djmd_content_item(ID="1", Title="Old")
+        mock_gfc.return_value.scalars.return_value.all.return_value = [content]
 
-        plan = plan_edit(mock_db, EditPlanArgs(field="Title", replace_value="Same"))
+        response = edit(
+            mock_db, EditArgs(field="Title", replace_value="New"), dry_run=True
+        )
 
-        assert plan.edits == []
+        assert isinstance(response, EditResponse)
+        assert response.result.field == "Title"
+        assert response.result.edits == [EditOp(id="1", new_value="New")]
+        assert response.tracks[0].ID == "1"
+        mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_raises_value_error_for_multi_without_flag(
+    def test_dry_run_surfaces_skipped(self, mock_gfc, mock_db, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1", Title="Same")
+        mock_gfc.return_value.scalars.return_value.all.return_value = [content]
+
+        response = edit(
+            mock_db, EditArgs(field="Title", replace_value="Same"), dry_run=True
+        )
+
+        assert response.result.edits == []
+        assert response.tracks == []
+        assert len(response.result.skipped) == 1
+        assert response.result.skipped[0].reason == "no_change"
+
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_dry_run_still_raises_multi_guard(
         self, mock_gfc, mock_db, make_djmd_content_item
     ):
-        content1 = make_djmd_content_item(ID="1", Title="Old")
-        content2 = make_djmd_content_item(ID="2", Title="Old")
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content1, content2]
-        mock_gfc.return_value = mock_result
+        # multi guard MUST still raise even in dry-run; it's a usage error,
+        # not a side effect. Verify behaviour matches real-run.
+        contents = [
+            make_djmd_content_item(ID="1", Title="Old"),
+            make_djmd_content_item(ID="2", Title="Old"),
+        ]
+        mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
         with pytest.raises(ValueError, match="multi"):
-            plan_edit(
-                mock_db, EditPlanArgs(field="Title", replace_value="New", multi=False)
+            edit(
+                mock_db,
+                EditArgs(field="Title", replace_value="New", multi=False),
+                dry_run=True,
             )
+
+
+class TestEditRealRun:
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_applies_changes_and_commits(
+        self, mock_gfc, mock_db, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1", Title="Old")
+        mock_gfc.return_value.scalars.return_value.all.return_value = [content]
+
+        response = edit(mock_db, EditArgs(field="Title", replace_value="New"))
+
+        assert content.Title == "New"
+        mock_db.session.commit.assert_called_once()
+        assert response.result.edits == [EditOp(id="1", new_value="New")]
+        assert response.tracks[0].ID == "1"
+
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_empty_result_returns_empty_response_without_commit(
+        self, mock_gfc, mock_db
+    ):
+        mock_gfc.return_value.scalars.return_value.all.return_value = []
+
+        response = edit(mock_db, EditArgs(field="Title", replace_value="New"))
+
+        assert response.result.edits == []
+        assert response.tracks == []
+        mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
     def test_multi_flag_allows_multiple_edits(
         self, mock_gfc, mock_db, make_djmd_content_item
     ):
-        content1 = make_djmd_content_item(ID="1", Title="Old")
-        content2 = make_djmd_content_item(ID="2", Title="Old")
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content1, content2]
-        mock_gfc.return_value = mock_result
+        contents = [
+            make_djmd_content_item(ID="1", Title="Old"),
+            make_djmd_content_item(ID="2", Title="Old"),
+        ]
+        mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        plan = plan_edit(
-            mock_db, EditPlanArgs(field="Title", replace_value="New", multi=True)
+        response = edit(
+            mock_db, EditArgs(field="Title", replace_value="New", multi=True)
         )
 
-        assert len(plan.edits) == 2
+        assert len(response.result.edits) == 2
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_match_pattern_applied(self, mock_gfc, mock_db, make_djmd_content_item):
-        content = make_djmd_content_item(Title="Hello World")
-        mock_result = Mock()
-        mock_result.scalars.return_value.all.return_value = [content]
-        mock_gfc.return_value = mock_result
-
-        plan = plan_edit(
-            mock_db,
-            EditPlanArgs(field="Title", replace_value="Earth", match_pattern="World"),
-        )
-
-        _, new_val = plan.edits[0]
-        assert new_val == "Hello Earth"
-
-
-class TestEdit:
-    def test_applies_changes_and_commits(self, mock_db, make_djmd_content_item):
-        content = make_djmd_content_item(ID="1", Title="Old")
-        mock_db.session.execute.return_value.scalars.return_value.all.return_value = [
-            content
+    def test_preserves_op_order_in_response_tracks(
+        self, mock_gfc, mock_db, make_djmd_content_item
+    ):
+        # Even if DB returns rows in non-input order, response.tracks aligns
+        # with response.result.edits.
+        contents = [
+            make_djmd_content_item(ID="C", Title="c-old"),
+            make_djmd_content_item(ID="A", Title="a-old"),
+            make_djmd_content_item(ID="B", Title="b-old"),
         ]
+        mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        track = Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav")
-        plan = EditPlan(field="Title", edits=[(track, "New Title")])
+        response = edit(mock_db, EditArgs(field="Title", replace_value="x", multi=True))
 
-        result = edit(mock_db, plan)
-
-        assert content.Title == "New Title"
-        mock_db.session.commit.assert_called_once()
-        assert isinstance(result, EditResult)
-        assert result.applied == 1
-
-    def test_empty_plan_returns_zero(self, mock_db):
-        plan = EditPlan(field="Title", edits=[])
-        result = edit(mock_db, plan)
-        assert result.applied == 0
-        mock_db.session.commit.assert_not_called()
+        # The order of result.edits follows the classifier (i.e. the order
+        # of contents). tracks aligns to edits.
+        ids = [t.ID for t in response.tracks]
+        assert ids == [op.id for op in response.result.edits]

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -23,7 +23,9 @@ class TestPlanEdit:
         assert new_val == "New"
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_skips_tracks_with_no_change(self, mock_gfc, mock_db, make_djmd_content_item):
+    def test_skips_tracks_with_no_change(
+        self, mock_gfc, mock_db, make_djmd_content_item
+    ):
         content = make_djmd_content_item(Title="Same")
         mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = [content]
@@ -44,7 +46,9 @@ class TestPlanEdit:
         mock_gfc.return_value = mock_result
 
         with pytest.raises(ValueError, match="multi"):
-            plan_edit(mock_db, EditPlanArgs(field="Title", replace_value="New", multi=False))
+            plan_edit(
+                mock_db, EditPlanArgs(field="Title", replace_value="New", multi=False)
+            )
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
     def test_multi_flag_allows_multiple_edits(
@@ -56,7 +60,9 @@ class TestPlanEdit:
         mock_result.scalars.return_value.all.return_value = [content1, content2]
         mock_gfc.return_value = mock_result
 
-        plan = plan_edit(mock_db, EditPlanArgs(field="Title", replace_value="New", multi=True))
+        plan = plan_edit(
+            mock_db, EditPlanArgs(field="Title", replace_value="New", multi=True)
+        )
 
         assert len(plan.edits) == 2
 
@@ -79,9 +85,11 @@ class TestPlanEdit:
 class TestEdit:
     def test_applies_changes_and_commits(self, mock_db, make_djmd_content_item):
         content = make_djmd_content_item(ID="1", Title="Old")
-        mock_db.session.execute.return_value.scalars.return_value.all.return_value = [content]
+        mock_db.session.execute.return_value.scalars.return_value.all.return_value = [
+            content
+        ]
 
-        track = Track(ID="1", Title="Old")
+        track = Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav")
         plan = EditPlan(field="Title", edits=[(track, "New Title")])
 
         result = edit(mock_db, plan)

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,22 +1,23 @@
 from unittest.mock import Mock, patch
 
 from rekordbox_edit.api.search import search
-from rekordbox_edit.models import FilterArgs, Track
+from rekordbox_edit.models import SearchArgs, SearchResponse, Track
 
 
 class TestSearch:
     @patch("rekordbox_edit.api.search.get_filtered_content")
-    def test_returns_list_of_tracks(self, mock_gfc, mock_db, make_djmd_content_item):
+    def test_returns_search_response(self, mock_gfc, mock_db, make_djmd_content_item):
         content = make_djmd_content_item(ID="ABC")
         mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = [content]
         mock_gfc.return_value = mock_result
 
-        result = search(mock_db, FilterArgs())
+        response = search(mock_db, SearchArgs())
 
-        assert len(result) == 1
-        assert isinstance(result[0], Track)
-        assert result[0].ID == "ABC"
+        assert isinstance(response, SearchResponse)
+        assert len(response.tracks) == 1
+        assert isinstance(response.tracks[0], Track)
+        assert response.tracks[0].ID == "ABC"
 
     @patch("rekordbox_edit.api.search.get_filtered_content")
     def test_empty_result(self, mock_gfc, mock_db):
@@ -24,9 +25,9 @@ class TestSearch:
         mock_result.scalars.return_value.all.return_value = []
         mock_gfc.return_value = mock_result
 
-        result = search(mock_db, FilterArgs())
+        response = search(mock_db, SearchArgs())
 
-        assert result == []
+        assert response.tracks == []
 
     @patch("rekordbox_edit.api.search.get_filtered_content")
     def test_passes_args_to_get_filtered_content(self, mock_gfc, mock_db):
@@ -34,7 +35,7 @@ class TestSearch:
         mock_result.scalars.return_value.all.return_value = []
         mock_gfc.return_value = mock_result
 
-        args = FilterArgs(artist=["Daft Punk"], match_all=True)
+        args = SearchArgs(artist=["Daft Punk"], match_all=True)
         search(mock_db, args)
 
         mock_gfc.assert_called_once_with(mock_db, args)

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,7 +1,7 @@
 """Tests for api/_utils.py."""
 
-from rekordbox_edit.api._utils import _track_from_content
-from rekordbox_edit.models import Track
+from rekordbox_edit.api._utils import _order_tracks_by_op, _track_from_content
+from rekordbox_edit.models import ConvertOp, Track
 
 
 class TestTrackFromContent:
@@ -21,3 +21,36 @@ class TestTrackFromContent:
         track = _track_from_content(content)
         assert track.ID == "99"
         assert isinstance(track.ID, str)
+
+
+class TestOrderTracksByOp:
+    def test_orders_tracks_to_match_ops(self, make_djmd_content_item):
+        # contents arrive in C,A,B order; ops in A,B,C order
+        contents = [
+            make_djmd_content_item(ID="C"),
+            make_djmd_content_item(ID="A"),
+            make_djmd_content_item(ID="B"),
+        ]
+        ops = [
+            ConvertOp(id="A", source_path="/a", output_path="/a.aif"),
+            ConvertOp(id="B", source_path="/b", output_path="/b.aif"),
+            ConvertOp(id="C", source_path="/c", output_path="/c.aif"),
+        ]
+
+        tracks = _order_tracks_by_op(contents, ops)
+
+        assert [t.ID for t in tracks] == ["A", "B", "C"]
+
+    def test_skips_ops_with_no_matching_content(self, make_djmd_content_item):
+        contents = [make_djmd_content_item(ID="A")]
+        ops = [
+            ConvertOp(id="A", source_path="/a", output_path="/a.aif"),
+            ConvertOp(id="MISSING", source_path="/x", output_path="/y"),
+        ]
+
+        tracks = _order_tracks_by_op(contents, ops)
+
+        assert [t.ID for t in tracks] == ["A"]
+
+    def test_empty_inputs_return_empty(self):
+        assert _order_tracks_by_op([], []) == []

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -13,6 +13,7 @@ from rekordbox_edit.models import (
     SkippedTrack,
     Track,
 )
+from rekordbox_edit.utils import UserQuit
 
 
 @pytest.fixture(autouse=True)
@@ -149,3 +150,121 @@ class TestConvertCommand:
         assert result.exit_code == 0
         payload = json.loads(result.output.splitlines()[-1])
         assert payload["result"]["format_out"] == "aiff"
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_default_flow_previews_then_commits(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        assert mock_convert.call_count == 2
+        assert mock_convert.call_args_list[0].kwargs.get("dry_run") is True
+        assert mock_convert.call_args_list[1].kwargs.get("dry_run", False) is False
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", return_value=False)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_default_flow_user_declines_skips_commit(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()  # preview only
+        assert mock_convert.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_default_flow_user_quit_skips_commit(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_default_flow_empty_preview_exits_cleanly(
+        self, _pid, mock_db_class, mock_convert
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = ConvertResponse(
+            tracks=[],
+            result=ConvertResult(
+                format_out="aiff", converted=[], deleted=0, skipped=[]
+            ),
+        )
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_interactive_narrows_to_confirmed_tracks(
+        self, _pid, mock_db_class, mock_convert, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        tracks = [
+            Track(ID="A", FileNameL="a.aiff", FolderPath="/a.aiff"),
+            Track(ID="B", FileNameL="b.aiff", FolderPath="/b.aiff"),
+        ]
+        ops = [
+            ConvertOp(id="A", source_path="/a.wav", output_path="/a.aiff"),
+            ConvertOp(id="B", source_path="/b.wav", output_path="/b.aiff"),
+        ]
+        mock_convert.return_value = _response(tracks=tracks, converted=ops)
+        # Confirm A, decline B.
+        mock_confirm.side_effect = [True, False]
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_convert.call_count == 2
+        narrowed_args = mock_convert.call_args_list[1].args[1]
+        assert narrowed_args.track_ids == ["A"]
+
+    @patch("rekordbox_edit.cli.convert._handle_stdin", return_value=False)
+    @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345)
+    def test_rekordbox_running_user_accepts_continues(
+        self, _pid, mock_db_class, _confirm, _stdin
+    ):
+        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
+            mock_db_class.return_value = Mock(session=Mock())
+            mock_convert.return_value = _response()
+
+            result = CliRunner().invoke(
+                convert_command, ["--format-out", "aiff", "--yes"]
+            )
+
+        assert result.exit_code == 0
+        mock_db_class.assert_called_once()

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -18,7 +18,7 @@ def mock_logger():
 
 def _make_plan(files=None, skipped=None, format_out="aiff", should_delete=True):
     return ConvertPlan(
-        files=files or [Track(ID="1", FileNameL="track.wav")],
+        files=files or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
         skipped=skipped or [],
         should_delete=should_delete,
         format_out=format_out,
@@ -64,7 +64,7 @@ class TestConvertCommand:
         self, mock_pid, mock_db_class, mock_plan, mock_logger
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        skipped = [Track(ID="2", FileNameL="conflict.wav")]
+        skipped = [Track(ID="2", FileNameL="conflict.wav", FolderPath="/conflict.wav")]
         mock_plan.return_value = _make_plan(skipped=skipped)
 
         with patch("rekordbox_edit.cli.convert.convert") as mock_convert:

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -170,3 +170,24 @@ class TestConvertCommand:
         )
 
         assert result.exit_code != 0
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.plan_convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_print_json_outputs_converted_tracks(
+        self, mock_pid, mock_db_class, mock_plan, mock_convert
+    ):
+        import json
+
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_plan.return_value = _make_plan()
+        mock_convert.return_value = Mock(converted=[{"content_id": "1"}], deleted=0)
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--yes", "--print", "json"]
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert [t["ID"] for t in payload] == ["1"]

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -5,9 +5,14 @@ from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
 
-from rekordbox_edit.api.convert import ConvertPlan
-from rekordbox_edit.models import Track
 from rekordbox_edit.cli.convert import convert_command
+from rekordbox_edit.models import (
+    ConvertOp,
+    ConvertResponse,
+    ConvertResult,
+    SkippedTrack,
+    Track,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -16,178 +21,131 @@ def mock_logger():
         yield mock_log
 
 
-def _make_plan(files=None, skipped=None, format_out="aiff", should_delete=True):
-    return ConvertPlan(
-        files=files or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
-        skipped=skipped or [],
-        should_delete=should_delete,
-        format_out=format_out,
+def _response(tracks=None, converted=None, deleted=0, skipped=None, format_out="aiff"):
+    tracks = tracks or [Track(ID="1", FileNameL="t.aiff", FolderPath="/t.aiff")]
+    converted = converted or [
+        ConvertOp(id=t.ID, source_path="/t.wav", output_path="/t.aiff") for t in tracks
+    ]
+    return ConvertResponse(
+        tracks=tracks,
+        result=ConvertResult(
+            format_out=format_out,
+            converted=converted,
+            deleted=deleted,
+            skipped=skipped or [],
+        ),
     )
 
 
 class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.plan_convert")
     @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
     @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_calls_convert_on_confirmation(
-        self, mock_pid, mock_db_class, mock_plan, mock_convert
-    ):
+    def test_yes_calls_convert_once(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-        mock_convert.return_value = Mock(converted=[{"content_id": "1"}], deleted=0)
+        mock_convert.return_value = _response()
 
         result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
 
         assert result.exit_code == 0
         mock_convert.assert_called_once()
 
-    @patch("rekordbox_edit.cli.convert.plan_convert")
+    @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
     @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_dry_run_does_not_call_convert(self, mock_pid, mock_db_class, mock_plan):
+    def test_dry_run(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
+        mock_convert.return_value = _response()
 
-        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
-            result = CliRunner().invoke(
-                convert_command, ["--format-out", "aiff", "--dry-run"]
-            )
-
-        assert result.exit_code == 0
-        mock_convert.assert_not_called()
-
-    @patch("rekordbox_edit.cli.convert.plan_convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_warns_about_skipped_files(
-        self, mock_pid, mock_db_class, mock_plan, mock_logger
-    ):
-        mock_db_class.return_value = Mock(session=Mock())
-        skipped = [Track(ID="2", FileNameL="conflict.wav", FolderPath="/conflict.wav")]
-        mock_plan.return_value = _make_plan(skipped=skipped)
-
-        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
-            mock_convert.return_value = Mock(converted=[], deleted=0)
-            CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
-
-        mock_logger.warning.assert_called()
-
-    @patch("rekordbox_edit.cli.convert.plan_convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_empty_plan_exits_early(self, mock_pid, mock_db_class, mock_plan):
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = ConvertPlan(
-            files=[], skipped=[], should_delete=True, format_out="aiff"
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--dry-run"]
         )
 
-        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
-            result = CliRunner().invoke(
-                convert_command, ["--format-out", "aiff", "--yes"]
-            )
-
         assert result.exit_code == 0
-        mock_convert.assert_not_called()
-
-    @patch("rekordbox_edit.cli.convert._handle_stdin", return_value=False)
-    @patch("rekordbox_edit.cli.convert._confirm_converts")
-    @patch("rekordbox_edit.cli.convert.plan_convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_cancellation_skips_convert(
-        self, mock_pid, mock_db_class, mock_plan, mock_confirm, _
-    ):
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-        mock_confirm.return_value = None
-
-        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
-            result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
-
-        assert result.exit_code == 0
-        mock_convert.assert_not_called()
+        mock_convert.assert_called_once()
+        assert mock_convert.call_args.kwargs.get("dry_run") is True
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.plan_convert")
     @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
     @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_logs_deleted_count(
-        self, mock_pid, mock_db_class, mock_plan, mock_convert, mock_logger
+    def test_warns_already_target_skip(
+        self, _pid, mock_db_class, mock_convert, mock_logger
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-        mock_convert.return_value = Mock(converted=[{"content_id": "1"}], deleted=2)
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="2", reason="already_target_format")]
+        )
+
+        CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
+
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("already" in w and "1" in w for w in warnings)
+        assert not any("--overwrite" in w for w in warnings)
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_warns_output_conflict_skip(
+        self, _pid, mock_db_class, mock_convert, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="2", reason="output_file_exists")]
+        )
+
+        CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
+
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("--overwrite" in w for w in warnings)
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    def test_logs_deleted_count(self, _pid, mock_db_class, mock_convert, mock_logger):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(deleted=2)
 
         CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
 
         mock_logger.info.assert_any_call("Deleted 2 original file(s)")
 
-    @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.plan_convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.confirm")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345)
-    def test_rekordbox_running_user_accepts_continues(
-        self, mock_pid, mock_confirm, mock_db_class, mock_plan, mock_convert
-    ):
-        mock_confirm.return_value = True
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-        mock_convert.return_value = Mock(converted=[], deleted=0)
-
-        result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
-
-        assert result.exit_code == 0
-        mock_db_class.assert_called_once()
-
     @patch("rekordbox_edit.cli.convert._handle_stdin", return_value=False)
     @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
     @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345)
-    def test_rekordbox_running_user_declines_returns_early(
-        self, mock_pid, mock_confirm, _
+    def test_rekordbox_running_user_declines(
+        self, _pid, mock_db_class, mock_confirm, _stdin
     ):
         mock_confirm.return_value = False
 
-        with patch("rekordbox_edit.cli.convert.Rekordbox6Database") as mock_db_class:
-            result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
 
         assert result.exit_code == 0
         mock_db_class.assert_not_called()
 
-    @patch("rekordbox_edit.cli.convert.plan_convert")
     @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_aborts_when_rekordbox_running_in_scripting_mode(
-        self, mock_pid, mock_db_class, mock_plan
-    ):
-        mock_pid.return_value = 12345
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-
-        result = CliRunner().invoke(
-            convert_command, ["--format-out", "aiff", "--yes", "--print", "silent"]
-        )
+    def test_aborts_in_scripting_mode_when_rekordbox_running(self, mock_db_class):
+        with patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345):
+            result = CliRunner().invoke(
+                convert_command,
+                ["--format-out", "aiff", "--yes", "--print", "silent"],
+            )
 
         assert result.exit_code != 0
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.plan_convert")
     @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
     @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
-    def test_print_json_outputs_converted_tracks(
-        self, mock_pid, mock_db_class, mock_plan, mock_convert
-    ):
+    def test_print_json_emits_envelope(self, _pid, mock_db_class, mock_convert):
         import json
 
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan.return_value = _make_plan()
-        mock_convert.return_value = Mock(converted=[{"content_id": "1"}], deleted=0)
+        mock_convert.return_value = _response()
 
         result = CliRunner().invoke(
             convert_command, ["--format-out", "aiff", "--yes", "--print", "json"]
         )
 
         assert result.exit_code == 0
-        payload = json.loads(result.output)
-        assert [t["ID"] for t in payload] == ["1"]
+        payload = json.loads(result.output.splitlines()[-1])
+        assert payload["result"]["format_out"] == "aiff"

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -5,9 +5,8 @@ from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
 
-from rekordbox_edit.api.edit import EditPlan
-from rekordbox_edit.models import Track
 from rekordbox_edit.cli.edit import edit_command
+from rekordbox_edit.models import EditOp, EditResponse, EditResult, Track
 
 
 @pytest.fixture(autouse=True)
@@ -16,96 +15,80 @@ def mock_logger():
         yield mock_log
 
 
-def _make_plan(field="Title", edits=None):
-    edits = edits or [
-        (Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav"), "New")
+def _response(tracks=None, edits=None, skipped=None):
+    tracks = tracks or [
+        Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")
     ]
-    return EditPlan(field=field, edits=edits)
+    edits = edits or [EditOp(id=t.ID, new_value="New") for t in tracks]
+    return EditResponse(
+        tracks=tracks,
+        result=EditResult(field="Title", edits=edits, skipped=skipped or []),
+    )
 
 
 class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.plan_edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_calls_edit_on_confirmation(self, mock_db_class, mock_plan_edit, mock_edit):
+    def test_yes_calls_edit_once(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan()
-        mock_edit.return_value = Mock(applied=1)
+        mock_edit.return_value = _response()
 
         result = CliRunner().invoke(
             edit_command, ["Title", "--replace", "New", "--yes"]
         )
 
         assert result.exit_code == 0
+        # exactly one call, dry_run not set
         mock_edit.assert_called_once()
+        assert mock_edit.call_args.kwargs.get("dry_run", False) is False
 
-    @patch("rekordbox_edit.cli.edit.plan_edit")
+    @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_dry_run_does_not_call_edit(self, mock_db_class, mock_plan_edit):
+    def test_dry_run_passes_flag_through(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan()
+        mock_edit.return_value = _response()
 
-        with patch("rekordbox_edit.cli.edit.edit") as mock_edit:
-            result = CliRunner().invoke(
-                edit_command, ["Title", "--replace", "New", "--dry-run"]
-            )
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--dry-run"]
+        )
 
         assert result.exit_code == 0
-        mock_edit.assert_not_called()
+        mock_edit.assert_called_once()
+        assert mock_edit.call_args.kwargs.get("dry_run") is True
 
-    @patch("rekordbox_edit.cli.edit.plan_edit")
+    @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_empty_plan_exits_early(self, mock_db_class, mock_plan_edit):
+    def test_empty_result_exits_cleanly(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = EditPlan(field="Title", edits=[])
+        mock_edit.return_value = _response(tracks=[], edits=[])
 
-        with patch("rekordbox_edit.cli.edit.edit") as mock_edit:
-            result = CliRunner().invoke(
-                edit_command, ["Title", "--replace", "New", "--yes"]
-            )
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes"]
+        )
 
         assert result.exit_code == 0
-        mock_edit.assert_not_called()
 
-    @patch("rekordbox_edit.cli.edit.plan_edit")
+    @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_value_error_becomes_usage_error(self, mock_db_class, mock_plan_edit):
+    def test_value_error_becomes_usage_error(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.side_effect = ValueError("Found 2 tracks that would be edited")
+        mock_edit.side_effect = ValueError("Found 2 tracks that would be edited")
 
-        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes"]
+        )
 
         assert result.exit_code != 0
         assert "Error" in result.output
 
-    @patch("rekordbox_edit.cli.edit._handle_stdin", return_value=False)
-    @patch("rekordbox_edit.cli.edit._confirm_edits")
-    @patch("rekordbox_edit.cli.edit.plan_edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_cancellation_skips_edit(
-        self, mock_db_class, mock_plan_edit, mock_confirm, _
-    ):
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan()
-        mock_confirm.return_value = None
-
-        with patch("rekordbox_edit.cli.edit.edit") as mock_edit:
-            result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
-
-        assert result.exit_code == 0
-        mock_edit.assert_not_called()
-
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.plan_edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_print_ids_outputs_applied_ids(
-        self, mock_db_class, mock_plan_edit, mock_edit
-    ):
+    def test_print_ids_outputs_ids(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan(
-            edits=[(Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav"), "New")]
+        track = Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav")
+        mock_edit.return_value = _response(
+            tracks=[track], edits=[EditOp(id="AAA", new_value="New")]
         )
-        mock_edit.return_value = Mock(applied=1)
 
         result = CliRunner().invoke(
             edit_command, ["Title", "--replace", "New", "--yes", "--print", "ids"]
@@ -115,23 +98,21 @@ class TestEditCommand:
         assert "AAA" in result.output
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.plan_edit")
     @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
-    def test_print_json_outputs_applied_tracks(
-        self, mock_db_class, mock_plan_edit, mock_edit
-    ):
+    def test_print_json_outputs_envelope(self, mock_db_class, mock_edit):
         import json
 
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan(
-            edits=[(Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav"), "New")]
+        track = Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav")
+        mock_edit.return_value = _response(
+            tracks=[track], edits=[EditOp(id="AAA", new_value="New")]
         )
-        mock_edit.return_value = Mock(applied=1)
 
         result = CliRunner().invoke(
             edit_command, ["Title", "--replace", "New", "--yes", "--print", "json"]
         )
 
         assert result.exit_code == 0
-        payload = json.loads(result.output)
-        assert [t["ID"] for t in payload] == ["AAA"]
+        payload = json.loads(result.output.splitlines()[-1])
+        assert payload["result"]["field"] == "Title"
+        assert payload["result"]["edits"] == [{"id": "AAA", "new_value": "New"}]

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -113,3 +113,25 @@ class TestEditCommand:
 
         assert result.exit_code == 0
         assert "AAA" in result.output
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.plan_edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_print_json_outputs_applied_tracks(
+        self, mock_db_class, mock_plan_edit, mock_edit
+    ):
+        import json
+
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_plan_edit.return_value = _make_plan(
+            edits=[(Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav"), "New")]
+        )
+        mock_edit.return_value = Mock(applied=1)
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes", "--print", "json"]
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert [t["ID"] for t in payload] == ["AAA"]

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -17,7 +17,9 @@ def mock_logger():
 
 
 def _make_plan(field="Title", edits=None):
-    edits = edits or [(Track(ID="1", Title="Old"), "New")]
+    edits = edits or [
+        (Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav"), "New")
+    ]
     return EditPlan(field=field, edits=edits)
 
 
@@ -100,7 +102,9 @@ class TestEditCommand:
         self, mock_db_class, mock_plan_edit, mock_edit
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_plan_edit.return_value = _make_plan(edits=[(Track(ID="AAA"), "New")])
+        mock_plan_edit.return_value = _make_plan(
+            edits=[(Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav"), "New")]
+        )
         mock_edit.return_value = Mock(applied=1)
 
         result = CliRunner().invoke(

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 
 from rekordbox_edit.cli.edit import edit_command
 from rekordbox_edit.models import EditOp, EditResponse, EditResult, Track
+from rekordbox_edit.utils import UserQuit
 
 
 @pytest.fixture(autouse=True)
@@ -116,3 +117,117 @@ class TestEditCommand:
         payload = json.loads(result.output.splitlines()[-1])
         assert payload["result"]["field"] == "Title"
         assert payload["result"]["edits"] == [{"id": "AAA", "new_value": "New"}]
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_default_flow_previews_then_commits(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response()
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code == 0
+        assert mock_edit.call_count == 2  # dry-run preview + real run
+        assert mock_edit.call_args_list[0].kwargs.get("dry_run") is True
+        assert mock_edit.call_args_list[1].kwargs.get("dry_run", False) is False
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", return_value=False)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_default_flow_user_declines_skips_commit(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response()
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()  # only the dry-run preview
+        assert mock_edit.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_default_flow_user_quit_skips_commit(
+        self, mock_db_class, mock_edit, _print, _confirm
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response()
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_default_flow_empty_preview_exits_cleanly(
+        self, mock_db_class, mock_edit, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = EditResponse(
+            tracks=[],
+            result=EditResult(field="Title", edits=[], skipped=[]),
+        )
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_interactive_narrows_to_confirmed_tracks(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        tracks = [
+            Track(ID="A", Title="OldA", FileNameL="a.wav", FolderPath="/a.wav"),
+            Track(ID="B", Title="OldB", FileNameL="b.wav", FolderPath="/b.wav"),
+        ]
+        edits = [
+            EditOp(id="A", new_value="NewA"),
+            EditOp(id="B", new_value="NewB"),
+        ]
+        mock_edit.return_value = _response(tracks=tracks, edits=edits)
+        # Confirm A, decline B.
+        mock_confirm.side_effect = [True, False]
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "NewA", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_edit.call_count == 2
+        narrowed_args = mock_edit.call_args_list[1].args[1]
+        assert narrowed_args.track_ids == ["A"]
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    def test_interactive_user_quit_skips_commit(
+        self, mock_db_class, mock_edit, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        tracks = [Track(ID="A", Title="O", FileNameL="a.wav", FolderPath="/a.wav")]
+        mock_edit.return_value = _response(
+            tracks=tracks, edits=[EditOp(id="A", new_value="N")]
+        )
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "N", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()  # preview only — UserQuit on first track

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -45,6 +45,24 @@ class TestSearchCommand:
     @patch("rekordbox_edit.cli.search.print_track_info")
     @patch("rekordbox_edit.cli.search.search")
     @patch("rekordbox_edit.cli.search.Rekordbox6Database")
+    def test_print_json_outputs_track_array(
+        self, mock_db_class, mock_search, mock_print, make_track
+    ):
+        import json
+
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_search.return_value = [make_track(ID="AAA111"), make_track(ID="BBB222")]
+
+        result = CliRunner().invoke(search_command, ["--print", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert [t["ID"] for t in payload] == ["AAA111", "BBB222"]
+        mock_print.assert_not_called()
+
+    @patch("rekordbox_edit.cli.search.print_track_info")
+    @patch("rekordbox_edit.cli.search.search")
+    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
     def test_print_silent_produces_no_output(
         self, mock_db_class, mock_search, mock_print, make_track
     ):

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -6,12 +6,17 @@ import pytest
 from click.testing import CliRunner
 
 from rekordbox_edit.cli.search import search_command
+from rekordbox_edit.models import SearchResponse
 
 
 @pytest.fixture(autouse=True)
 def mock_logger():
     with patch("rekordbox_edit.cli.search.logger") as mock_log:
         yield mock_log
+
+
+def _response(*tracks):
+    return SearchResponse(tracks=list(tracks))
 
 
 class TestSearchCommand:
@@ -22,7 +27,7 @@ class TestSearchCommand:
         self, mock_db_class, mock_search, mock_print, make_track
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = [make_track(ID="AAA111")]
+        mock_search.return_value = _response(make_track(ID="AAA111"))
 
         result = CliRunner().invoke(search_command, [])
 
@@ -31,74 +36,38 @@ class TestSearchCommand:
 
     @patch("rekordbox_edit.cli.search.search")
     @patch("rekordbox_edit.cli.search.Rekordbox6Database")
-    def test_print_ids_outputs_space_separated_ids(
-        self, mock_db_class, mock_search, make_track
-    ):
+    def test_print_ids(self, mock_db_class, mock_search, make_track):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = [make_track(ID="AAA111"), make_track(ID="BBB222")]
+        mock_search.return_value = _response(make_track(ID="A"), make_track(ID="B"))
 
         result = CliRunner().invoke(search_command, ["--print", "ids"])
 
         assert result.exit_code == 0
-        assert "AAA111 BBB222" in result.output
+        assert "A B" in result.output
 
-    @patch("rekordbox_edit.cli.search.print_track_info")
     @patch("rekordbox_edit.cli.search.search")
     @patch("rekordbox_edit.cli.search.Rekordbox6Database")
-    def test_print_json_outputs_track_array(
-        self, mock_db_class, mock_search, mock_print, make_track
-    ):
+    def test_print_json_emits_envelope(self, mock_db_class, mock_search, make_track):
         import json
 
         mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = [make_track(ID="AAA111"), make_track(ID="BBB222")]
+        mock_search.return_value = _response(make_track(ID="A"))
 
         result = CliRunner().invoke(search_command, ["--print", "json"])
 
         assert result.exit_code == 0
         payload = json.loads(result.output)
-        assert [t["ID"] for t in payload] == ["AAA111", "BBB222"]
-        mock_print.assert_not_called()
+        assert payload["tracks"][0]["ID"] == "A"
 
-    @patch("rekordbox_edit.cli.search.print_track_info")
     @patch("rekordbox_edit.cli.search.search")
     @patch("rekordbox_edit.cli.search.Rekordbox6Database")
     def test_print_silent_produces_no_output(
-        self, mock_db_class, mock_search, mock_print, make_track
+        self, mock_db_class, mock_search, make_track
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = [make_track(ID="AAA111")]
+        mock_search.return_value = _response(make_track(ID="A"))
 
         result = CliRunner().invoke(search_command, ["--print", "silent"])
 
         assert result.exit_code == 0
         assert result.output.strip() == ""
-        mock_print.assert_not_called()
-
-    @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
-    def test_filters_forwarded_to_search(self, mock_db_class, mock_search):
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = []
-
-        CliRunner().invoke(
-            search_command,
-            ["--artist", "Daft Punk", "--format", "flac", "--match-all"],
-        )
-
-        args = mock_search.call_args.args[1]
-        assert args.artist == ["Daft Punk"]
-        assert args.format == ["flac"]
-        assert args.match_all is True
-
-    @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
-    def test_reads_track_ids_from_stdin(self, mock_db_class, mock_search):
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_search.return_value = []
-
-        CliRunner().invoke(search_command, [], input="AAA111 BBB222")
-
-        args = mock_search.call_args.args[1]
-        assert "AAA111" in args.track_ids
-        assert "BBB222" in args.track_ids

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -4,34 +4,25 @@ import click
 import pytest
 
 from rekordbox_edit._click import PrintChoice
-from rekordbox_edit.api.convert import ConvertPlan
-from rekordbox_edit.api.edit import EditPlan
 from rekordbox_edit.cli._utils import (
-    _confirm_converts,
-    _confirm_edits,
     _handle_stdin,
-    _interactive_filter_converts,
-    _interactive_filter_edits,
+    _narrow_to_track_ids,
+    _print_response_ids,
+    _print_response_json,
     _validate_scripting_preconditions,
 )
-from rekordbox_edit.models import Track
-from rekordbox_edit.utils import UserQuit
-
-
-def _edit_plan(edits=None):
-    edits = edits or [
-        (Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav"), "New")
-    ]
-    return EditPlan(field="Title", edits=edits)
-
-
-def _convert_plan(files=None):
-    return ConvertPlan(
-        files=files or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
-        skipped=[],
-        should_delete=True,
-        format_out="aiff",
-    )
+from rekordbox_edit.models import (
+    ConvertArgs,
+    ConvertOp,
+    ConvertResponse,
+    ConvertResult,
+    EditArgs,
+    EditOp,
+    EditResponse,
+    EditResult,
+    SearchResponse,
+    Track,
+)
 
 
 class TestHandleStdin:
@@ -39,8 +30,7 @@ class TestHandleStdin:
         args = Mock()
         with patch("sys.stdin") as mock_stdin:
             mock_stdin.isatty.return_value = True
-            result = _handle_stdin(args)
-        assert result is False
+            assert _handle_stdin(args) is False
 
     def test_appends_ids_from_piped_stdin(self):
         args = Mock(track_ids=["existing"])
@@ -80,168 +70,102 @@ class TestHandleStdin:
 
 
 class TestValidateScriptingPreconditions:
-    def test_scripting_mode_without_confirmation_flag_raises(self):
+    def test_scripting_mode_without_confirmation_raises(self):
         args = Mock(dry_run=False, yes=False)
         with pytest.raises(click.UsageError):
             _validate_scripting_preconditions(PrintChoice.IDS, args, piped_stdin=False)
 
-    def test_scripting_mode_with_yes_does_not_raise(self):
+    def test_scripting_mode_with_yes_ok(self):
         args = Mock(dry_run=False, yes=True)
         _validate_scripting_preconditions(PrintChoice.IDS, args, piped_stdin=False)
 
-    def test_scripting_mode_with_dry_run_does_not_raise(self):
-        args = Mock(dry_run=True, yes=False)
-        _validate_scripting_preconditions(PrintChoice.SILENT, args, piped_stdin=False)
-
-    def test_piped_stdin_without_confirmation_flag_raises(self):
+    def test_piped_stdin_without_confirmation_raises(self):
         args = Mock(dry_run=False, yes=False)
         with pytest.raises(click.UsageError, match="Piping"):
             _validate_scripting_preconditions(None, args, piped_stdin=True)
 
-    def test_piped_stdin_with_yes_does_not_raise(self):
-        args = Mock(dry_run=False, yes=True)
-        _validate_scripting_preconditions(None, args, piped_stdin=True)
 
-    def test_normal_mode_no_stdin_does_not_raise(self):
-        args = Mock(dry_run=False, yes=False)
-        _validate_scripting_preconditions(None, args, piped_stdin=False)
-
-    def test_json_mode_without_confirmation_flag_raises(self):
-        args = Mock(dry_run=False, yes=False)
-        with pytest.raises(click.UsageError):
-            _validate_scripting_preconditions(PrintChoice.JSON, args, piped_stdin=False)
-
-    def test_json_mode_with_yes_does_not_raise(self):
-        args = Mock(dry_run=False, yes=True)
-        _validate_scripting_preconditions(PrintChoice.JSON, args, piped_stdin=False)
-
-
-class TestConfirmEdits:
-    def test_yes_returns_plan_immediately(self):
-        plan = _edit_plan()
-        args = Mock(yes=True, interactive=False)
-        assert _confirm_edits(plan, args) is plan
-
-    def test_interactive_delegates_to_filter(self):
-        plan = _edit_plan()
-        args = Mock(yes=False, interactive=True)
-        with patch(
-            "rekordbox_edit.cli._utils._interactive_filter_edits", return_value=plan
-        ) as mock_filter:
-            result = _confirm_edits(plan, args)
-        mock_filter.assert_called_once_with(plan)
-        assert result is plan
-
-    def test_user_declines_returns_none(self):
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", return_value=False):
-            result = _confirm_edits(_edit_plan(), args)
-        assert result is None
-
-    def test_user_quit_returns_none(self):
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
-            result = _confirm_edits(_edit_plan(), args)
-        assert result is None
-
-    def test_user_confirms_returns_plan(self):
-        plan = _edit_plan()
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", return_value=True):
-            result = _confirm_edits(plan, args)
-        assert result is plan
-
-
-class TestInteractiveFilterEdits:
-    def test_includes_confirmed_tracks_excludes_declined(self):
-        track1 = Track(ID="1", Title="A", FileNameL="a.wav", FolderPath="/a.wav")
-        track2 = Track(ID="2", Title="B", FileNameL="b.wav", FolderPath="/b.wav")
-        plan = EditPlan(field="Title", edits=[(track1, "X"), (track2, "Y")])
-
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=[True, False]):
-            result = _interactive_filter_edits(plan)
-
-        assert len(result.edits) == 1
-        assert result.edits[0][0].ID == "1"
-
-    def test_user_quit_stops_iteration_early(self):
-        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
-        track2 = Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")
-        plan = EditPlan(field="Title", edits=[(track1, "X"), (track2, "Y")])
-
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
-            result = _interactive_filter_edits(plan)
-
-        assert result.edits == []
-
-
-class TestConfirmConverts:
-    def test_yes_returns_plan_immediately(self):
-        plan = _convert_plan()
-        args = Mock(yes=True, interactive=False)
-        assert _confirm_converts(plan, args) is plan
-
-    def test_interactive_delegates_to_filter(self):
-        plan = _convert_plan()
-        args = Mock(yes=False, interactive=True)
-        with patch(
-            "rekordbox_edit.cli._utils._interactive_filter_converts", return_value=plan
-        ) as mock_filter:
-            result = _confirm_converts(plan, args)
-        mock_filter.assert_called_once_with(plan)
-        assert result is plan
-
-    def test_user_declines_returns_none(self):
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", return_value=False):
-            result = _confirm_converts(_convert_plan(), args)
-        assert result is None
-
-    def test_user_quit_returns_none(self):
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
-            result = _confirm_converts(_convert_plan(), args)
-        assert result is None
-
-    def test_user_confirms_returns_plan(self):
-        plan = _convert_plan()
-        args = Mock(yes=False, interactive=False)
-        with patch("rekordbox_edit.cli._utils.confirm", return_value=True):
-            result = _confirm_converts(plan, args)
-        assert result is plan
-
-
-class TestInteractiveFilterConverts:
-    def test_includes_confirmed_tracks_excludes_declined(self):
-        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
-        track2 = Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")
-        plan = _convert_plan([track1, track2])
-
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=[True, False]):
-            result = _interactive_filter_converts(plan)
-
-        assert len(result.files) == 1
-        assert result.files[0].ID == "1"
-
-    def test_user_quit_stops_iteration_early(self):
-        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
-        plan = _convert_plan([track1])
-
-        with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
-            result = _interactive_filter_converts(plan)
-
-        assert result.files == []
-
-    def test_preserves_plan_metadata(self):
-        plan = ConvertPlan(
-            files=[Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")],
-            skipped=[Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")],
-            should_delete=False,
-            format_out="mp3",
+class TestNarrowToTrackIds:
+    def test_clears_other_filter_criteria(self):
+        args = ConvertArgs(
+            artist=["X"],
+            format=["flac"],
+            format_out="aiff",
+            overwrite=True,
+            delete=True,
         )
-        with patch("rekordbox_edit.cli._utils.confirm", return_value=True):
-            result = _interactive_filter_converts(plan)
 
-        assert result.should_delete is False
-        assert result.format_out == "mp3"
-        assert result.skipped == plan.skipped
+        narrowed = _narrow_to_track_ids(args, ["a", "b"])
+
+        assert narrowed.track_ids == ["a", "b"]
+        assert narrowed.artist == []
+        assert narrowed.format == []
+        # Convert-specific fields preserved
+        assert narrowed.format_out == "aiff"
+        assert narrowed.overwrite is True
+        assert narrowed.delete is True
+
+    def test_works_for_edit_args(self):
+        args = EditArgs(
+            artist=["X"],
+            field="Title",
+            replace_value="N",
+            match_pattern="O",
+            multi=True,
+        )
+
+        narrowed = _narrow_to_track_ids(args, ["a"])
+
+        assert narrowed.track_ids == ["a"]
+        assert narrowed.artist == []
+        # Edit-specific fields preserved
+        assert narrowed.field == "Title"
+        assert narrowed.replace_value == "N"
+        assert narrowed.match_pattern == "O"
+        assert narrowed.multi is True
+
+
+class TestPrintResponseIds:
+    def test_prints_space_separated_ids(self, capsys):
+        track = Track(ID="1", FileNameL="x", FolderPath="/x")
+        resp = SearchResponse(
+            tracks=[track, Track(ID="2", FileNameL="y", FolderPath="/y")]
+        )
+        _print_response_ids(resp)
+        assert capsys.readouterr().out.strip() == "1 2"
+
+
+class TestPrintResponseJson:
+    def test_emits_envelope_json(self, capsys):
+        track = Track(ID="1", FileNameL="x", FolderPath="/x")
+        resp = EditResponse(
+            tracks=[track],
+            result=EditResult(
+                field="Title", edits=[EditOp(id="1", new_value="N")], skipped=[]
+            ),
+        )
+        _print_response_json(resp)
+        import json
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["tracks"][0]["ID"] == "1"
+        assert payload["result"]["field"] == "Title"
+
+    def test_convert_response_json(self, capsys):
+        track = Track(ID="1", FileNameL="x.aif", FolderPath="/x.aif")
+        resp = ConvertResponse(
+            tracks=[track],
+            result=ConvertResult(
+                format_out="aiff",
+                converted=[
+                    ConvertOp(id="1", source_path="/x.wav", output_path="/x.aif")
+                ],
+                deleted=0,
+                skipped=[],
+            ),
+        )
+        _print_response_json(resp)
+        import json
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["result"]["format_out"] == "aiff"

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -106,6 +106,15 @@ class TestValidateScriptingPreconditions:
         args = Mock(dry_run=False, yes=False)
         _validate_scripting_preconditions(None, args, piped_stdin=False)
 
+    def test_json_mode_without_confirmation_flag_raises(self):
+        args = Mock(dry_run=False, yes=False)
+        with pytest.raises(click.UsageError):
+            _validate_scripting_preconditions(PrintChoice.JSON, args, piped_stdin=False)
+
+    def test_json_mode_with_yes_does_not_raise(self):
+        args = Mock(dry_run=False, yes=True)
+        _validate_scripting_preconditions(PrintChoice.JSON, args, piped_stdin=False)
+
 
 class TestConfirmEdits:
     def test_yes_returns_plan_immediately(self):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -19,13 +19,15 @@ from rekordbox_edit.utils import UserQuit
 
 
 def _edit_plan(edits=None):
-    edits = edits or [(Track(ID="1", Title="Old"), "New")]
+    edits = edits or [
+        (Track(ID="1", Title="Old", FileNameL="x.wav", FolderPath="/x.wav"), "New")
+    ]
     return EditPlan(field="Title", edits=edits)
 
 
 def _convert_plan(files=None):
     return ConvertPlan(
-        files=files or [Track(ID="1", FileNameL="track.wav")],
+        files=files or [Track(ID="1", FileNameL="track.wav", FolderPath="/track.wav")],
         skipped=[],
         should_delete=True,
         format_out="aiff",
@@ -143,8 +145,8 @@ class TestConfirmEdits:
 
 class TestInteractiveFilterEdits:
     def test_includes_confirmed_tracks_excludes_declined(self):
-        track1 = Track(ID="1", Title="A")
-        track2 = Track(ID="2", Title="B")
+        track1 = Track(ID="1", Title="A", FileNameL="a.wav", FolderPath="/a.wav")
+        track2 = Track(ID="2", Title="B", FileNameL="b.wav", FolderPath="/b.wav")
         plan = EditPlan(field="Title", edits=[(track1, "X"), (track2, "Y")])
 
         with patch("rekordbox_edit.cli._utils.confirm", side_effect=[True, False]):
@@ -154,8 +156,8 @@ class TestInteractiveFilterEdits:
         assert result.edits[0][0].ID == "1"
 
     def test_user_quit_stops_iteration_early(self):
-        track1 = Track(ID="1")
-        track2 = Track(ID="2")
+        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
+        track2 = Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")
         plan = EditPlan(field="Title", edits=[(track1, "X"), (track2, "Y")])
 
         with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
@@ -202,8 +204,8 @@ class TestConfirmConverts:
 
 class TestInteractiveFilterConverts:
     def test_includes_confirmed_tracks_excludes_declined(self):
-        track1 = Track(ID="1", FileNameL="a.wav")
-        track2 = Track(ID="2", FileNameL="b.wav")
+        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
+        track2 = Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")
         plan = _convert_plan([track1, track2])
 
         with patch("rekordbox_edit.cli._utils.confirm", side_effect=[True, False]):
@@ -213,7 +215,7 @@ class TestInteractiveFilterConverts:
         assert result.files[0].ID == "1"
 
     def test_user_quit_stops_iteration_early(self):
-        track1 = Track(ID="1", FileNameL="a.wav")
+        track1 = Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")
         plan = _convert_plan([track1])
 
         with patch("rekordbox_edit.cli._utils.confirm", side_effect=UserQuit):
@@ -223,8 +225,8 @@ class TestInteractiveFilterConverts:
 
     def test_preserves_plan_metadata(self):
         plan = ConvertPlan(
-            files=[Track(ID="1", FileNameL="a.wav")],
-            skipped=[Track(ID="2")],
+            files=[Track(ID="1", FileNameL="a.wav", FolderPath="/a.wav")],
+            skipped=[Track(ID="2", FileNameL="b.wav", FolderPath="/b.wav")],
             should_delete=False,
             format_out="mp3",
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,10 @@ def make_djmd_content_item():
         id = id or str(ID)
 
         item_mock = MagicMock()
+        # Default every real column to None so bulk-copy in _track_from_content
+        # sees a clean row instead of MagicMock placeholders.
+        for col in DjmdContent.__table__.columns:
+            setattr(item_mock, col.key, None)
         item: DjmdContent = cast(DjmdContent, item_mock)
         item.ID = kwargs.get("ID", id)
         item.Title = kwargs.get("Title", "Test Song")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -145,9 +145,7 @@ class TestPrintTrackInfo:
         assert "FLAC" in captured.out
         assert "MP3" in captured.out
 
-    def test_track_with_unknown_file_type(
-        self, capsys, wide_console, make_track
-    ):
+    def test_track_with_unknown_file_type(self, capsys, wide_console, make_track):
         """Test printing track with unknown file type."""
         mock_content = make_track(
             ID="123",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,8 +17,8 @@ from rekordbox_edit.models import (
 
 
 class TestTrack:
-    def test_construction_with_id_only(self):
-        track = Track(ID="123")
+    def test_construction_with_required_fields(self):
+        track = Track(ID="123", FileNameL="x.wav", FolderPath="/x.wav")
         assert track.ID == "123"
         assert track.Title is None
         assert track.ArtistName is None
@@ -39,9 +39,17 @@ class TestTrack:
         assert track.FileType == 11
         assert track.SampleRate == 44100
 
-    def test_extra_fields_forbidden(self):
-        with pytest.raises(ValidationError):
-            Track.model_validate({"ID": "1", "unknown_field": "x"})
+    def test_extra_fields_allowed(self):
+        track = Track.model_validate(
+            {
+                "ID": "1",
+                "FileNameL": "x.wav",
+                "FolderPath": "/x.wav",
+                "unknown_field": "x",
+            }
+        )
+        assert track.ID == "1"
+        assert track.unknown_field == "x"
 
 
 class TestFilterArgs:
@@ -78,7 +86,9 @@ class TestEditArgs:
 
     def test_extra_fields_forbidden(self):
         with pytest.raises(ValidationError):
-            EditArgs.model_validate({"field": "Title", "replace_value": "x", "unknown": "y"})
+            EditArgs.model_validate(
+                {"field": "Title", "replace_value": "x", "unknown": "y"}
+            )
 
 
 class TestConvertArgs:
@@ -106,7 +116,9 @@ class TestEditPlanArgs:
 
     def test_extra_fields_forbidden(self):
         with pytest.raises(ValidationError):
-            EditPlanArgs.model_validate({"field": "Title", "replace_value": "x", "dry_run": True})
+            EditPlanArgs.model_validate(
+                {"field": "Title", "replace_value": "x", "dry_run": True}
+            )
 
 
 class TestConvertPlanArgs:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,14 +4,18 @@ import pytest
 from pydantic import ValidationError
 
 from rekordbox_edit.models import (
-    ConfirmationArgs,
     ConvertArgs,
-    ConvertCommandArgs,
-    ConvertPlanArgs,
+    ConvertOp,
+    ConvertResponse,
+    ConvertResult,
     EditArgs,
-    EditCommandArgs,
-    EditPlanArgs,
+    EditOp,
+    EditResponse,
+    EditResult,
     FilterArgs,
+    SearchArgs,
+    SearchResponse,
+    SkippedTrack,
     Track,
 )
 
@@ -23,33 +27,11 @@ class TestTrack:
         assert track.Title is None
         assert track.ArtistName is None
 
-    def test_all_fields(self):
-        track = Track(
-            ID="abc",
-            Title="Song",
-            ArtistName="Artist",
-            AlbumName="Album",
-            FileNameL="song.aif",
-            FolderPath="/music/song.aif",
-            FileType=11,
-            SampleRate=44100,
-            BitDepth=16,
-            BitRate=1411,
-        )
-        assert track.FileType == 11
-        assert track.SampleRate == 44100
-
     def test_extra_fields_allowed(self):
         track = Track.model_validate(
-            {
-                "ID": "1",
-                "FileNameL": "x.wav",
-                "FolderPath": "/x.wav",
-                "unknown_field": "x",
-            }
+            {"ID": "1", "FileNameL": "x.wav", "FolderPath": "/x.wav", "extra": "x"}
         )
-        assert track.ID == "1"
-        assert track.unknown_field == "x"
+        assert getattr(track, "extra") == "x"
 
 
 class TestFilterArgs:
@@ -64,98 +46,128 @@ class TestFilterArgs:
             FilterArgs.model_validate({"unknown": "x"})
 
 
-class TestConfirmationArgs:
-    def test_defaults(self):
-        args = ConfirmationArgs()
-        assert args.dry_run is False
-        assert args.yes is False
-        assert args.interactive is False
-
-    def test_extra_fields_forbidden(self):
-        with pytest.raises(ValidationError):
-            ConfirmationArgs.model_validate({"unknown": "x"})
+class TestSearchArgs:
+    def test_is_filter_args(self):
+        args = SearchArgs(artist=["X"])
+        assert isinstance(args, FilterArgs)
+        assert args.artist == ["X"]
 
 
 class TestEditArgs:
-    def test_required_fields(self):
-        args = EditArgs(field="Title", replace_value="New")
+    def test_has_filter_and_edit_fields(self):
+        args = EditArgs(field="Title", replace_value="New", artist=["X"])
+        assert isinstance(args, FilterArgs)
         assert args.field == "Title"
         assert args.replace_value == "New"
-        assert args.match_pattern is None
+        assert args.artist == ["X"]
         assert args.multi is False
-
-    def test_extra_fields_forbidden(self):
-        with pytest.raises(ValidationError):
-            EditArgs.model_validate(
-                {"field": "Title", "replace_value": "x", "unknown": "y"}
-            )
 
 
 class TestConvertArgs:
-    def test_defaults(self):
-        args = ConvertArgs()
-        assert args.format_out == "aiff"
+    def test_has_filter_and_convert_fields(self):
+        args = ConvertArgs(format_out="mp3", overwrite=True, artist=["X"])
+        assert isinstance(args, FilterArgs)
+        assert args.format_out == "mp3"
+        assert args.overwrite is True
         assert args.delete is None
-        assert args.overwrite is False
-
-    def test_delete_tri_state(self):
-        assert ConvertArgs(delete=True).delete is True
-        assert ConvertArgs(delete=False).delete is False
-        assert ConvertArgs().delete is None
+        assert args.artist == ["X"]
 
 
-class TestEditPlanArgs:
-    def test_inherits_filter_and_edit_fields(self):
-        args = EditPlanArgs(field="Title", replace_value="New")
-        assert args.field == "Title"
-        assert args.match_all is False
-        assert args.multi is False
+class TestSkippedTrack:
+    def test_known_reasons_accepted(self):
+        assert SkippedTrack(id="1", reason="no_change").reason == "no_change"
+        assert (
+            SkippedTrack(id="1", reason="already_target_format").reason
+            == "already_target_format"
+        )
+        assert (
+            SkippedTrack(id="1", reason="output_file_exists").reason
+            == "output_file_exists"
+        )
 
-    def test_no_confirmation_fields(self):
-        assert "dry_run" not in EditPlanArgs.model_fields
-
-    def test_extra_fields_forbidden(self):
+    def test_unknown_reason_rejected(self):
         with pytest.raises(ValidationError):
-            EditPlanArgs.model_validate(
-                {"field": "Title", "replace_value": "x", "dry_run": True}
+            SkippedTrack(id="1", reason="nope")  # ty: ignore[invalid-argument-type]
+
+
+class TestEditResponseAlignment:
+    def test_rejects_mismatched_lengths(self):
+        track = Track(ID="1", FileNameL="x.wav", FolderPath="/x.wav")
+        with pytest.raises(ValidationError, match="align"):
+            EditResponse(
+                tracks=[track, track],
+                result=EditResult(
+                    field="Title",
+                    edits=[EditOp(id="1", new_value="X")],
+                    skipped=[],
+                ),
             )
 
-
-class TestConvertPlanArgs:
-    def test_inherits_filter_and_convert_fields(self):
-        args = ConvertPlanArgs(format_out="aiff")
-        assert args.format_out == "aiff"
-        assert args.match_all is False
-
-    def test_no_confirmation_fields(self):
-        assert "dry_run" not in ConvertPlanArgs.model_fields
-
-
-class TestEditCommandArgs:
-    def test_has_all_fields(self):
-        args = EditCommandArgs(field="Title", replace_value="New")
-        assert args.field == "Title"
-        assert args.dry_run is False
-        assert args.yes is False
-        assert args.interactive is False
-
-    def test_is_subtype_of_edit_plan_args(self):
-        args = EditCommandArgs(field="Title", replace_value="X")
-        assert isinstance(args, EditPlanArgs)
-
-    def test_no_print_opt(self):
-        assert "print_opt" not in EditCommandArgs.model_fields
+    def test_accepts_matched_lengths(self):
+        track = Track(ID="1", FileNameL="x.wav", FolderPath="/x.wav")
+        EditResponse(
+            tracks=[track],
+            result=EditResult(
+                field="Title",
+                edits=[EditOp(id="1", new_value="X")],
+                skipped=[],
+            ),
+        )
 
 
-class TestConvertCommandArgs:
-    def test_has_all_fields(self):
-        args = ConvertCommandArgs(format_out="mp3")
-        assert args.format_out == "mp3"
-        assert args.dry_run is False
+class TestConvertResponseAlignment:
+    def test_rejects_mismatched_lengths(self):
+        track = Track(ID="1", FileNameL="x.aif", FolderPath="/x.aif")
+        with pytest.raises(ValidationError, match="align"):
+            ConvertResponse(
+                tracks=[track, track],
+                result=ConvertResult(
+                    format_out="aiff",
+                    converted=[
+                        ConvertOp(id="1", source_path="/x.wav", output_path="/x.aif")
+                    ],
+                    deleted=0,
+                    skipped=[],
+                ),
+            )
 
-    def test_is_subtype_of_convert_plan_args(self):
-        args = ConvertCommandArgs(format_out="flac")
-        assert isinstance(args, ConvertPlanArgs)
+    def test_accepts_matched_lengths(self):
+        track = Track(ID="1", FileNameL="x.aif", FolderPath="/x.aif")
+        ConvertResponse(
+            tracks=[track],
+            result=ConvertResult(
+                format_out="aiff",
+                converted=[
+                    ConvertOp(id="1", source_path="/x.wav", output_path="/x.aif")
+                ],
+                deleted=0,
+                skipped=[],
+            ),
+        )
 
-    def test_no_print_opt(self):
-        assert "print_opt" not in ConvertCommandArgs.model_fields
+
+class TestEditResultCarriesField:
+    def test_field_required(self):
+        with pytest.raises(ValidationError):
+            EditResult(edits=[], skipped=[])  # ty: ignore[missing-argument]  # missing field
+
+    def test_field_accessible(self):
+        r = EditResult(field="Title", edits=[], skipped=[])
+        assert r.field == "Title"
+
+
+class TestConvertResultCarriesFormatOut:
+    def test_format_out_required(self):
+        with pytest.raises(ValidationError):
+            ConvertResult(converted=[], deleted=0, skipped=[])  # ty: ignore[missing-argument]  # missing format_out
+
+    def test_format_out_accessible(self):
+        r = ConvertResult(format_out="aiff", converted=[], deleted=0, skipped=[])
+        assert r.format_out == "aiff"
+
+
+class TestSearchResponse:
+    def test_construction(self):
+        track = Track(ID="1", FileNameL="x.wav", FolderPath="/x.wav")
+        resp = SearchResponse(tracks=[track])
+        assert resp.tracks[0].ID == "1"


### PR DESCRIPTION
The `plan_command()` / `command()` API was flawed, the Plan endpoints were only really useful to the CLI, but were being forced on the API user. This clears that up, I think I'm happy with this moving forward.

Also adds a `--print json` arg for dumping the API response as JSON for more complex command piping. Also makes it trivial for users to inspect exactly what the database says, v.s. how we format things. 