### PR TITLE
feat: adds global --database-path argument

### DIFF
--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pathlib import Path
 
 import click
 
@@ -161,6 +162,15 @@ convert_click_options = [
         help="Output format (default: aiff)",
     ),
 ]
+
+
+database_path_option = click.option(
+    "--database-path",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    envvar="RBE_DATABASE_PATH",
+    help="Path to master.db. Bypasses Rekordbox installation discovery.",
+)
 
 
 def add_click_options(options):

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,13 +1,17 @@
 """CLI-private helpers: stdin handling, scripting guards, args narrowing, print emitters."""
 
+import functools
 import logging
 import sys
 from copy import copy
 
 import click
 from pydantic import BaseModel
+from pyrekordbox import Rekordbox6Database
+from pyrekordbox.utils import get_rekordbox_pid
 
-from rekordbox_edit._click import PrintChoice
+from rekordbox_edit._click import PrintChoice, database_path_option
+from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -77,3 +81,47 @@ def _print_response_ids(response) -> None:
 def _print_response_json(response: BaseModel) -> None:
     """Print the response envelope as JSON."""
     print(response.model_dump_json())
+
+
+def _rekordbox_running_confirm(print_opt) -> bool:
+    rekordbox_pid = get_rekordbox_pid()
+    if not rekordbox_pid:
+        return True
+    if print_opt in SCRIPTING_MODES:
+        logger.error(
+            f"Rekordbox is running (PID {rekordbox_pid}). Cannot proceed in scripting mode."
+        )
+        sys.exit(1)
+    logger.warning(
+        f"Rekordbox is running (PID {rekordbox_pid}). Modifying the database while "
+        "Rekordbox is open can cause conflicts."
+    )
+    try:
+        return confirm("Continue anyway?", default=False)
+    except UserQuit:
+        return False
+
+
+def with_database(*, writes: bool = False):
+    """Inject an opened Rekordbox6Database as `db` and close it on exit.
+
+    Pass writes=True for commands that modify the DB: the wrapper aborts when
+    Rekordbox is running (or prompts to continue in interactive modes).
+    """
+
+    def decorator(func):
+        @database_path_option
+        @functools.wraps(func)
+        def wrapper(**kwargs):
+            if writes and not _rekordbox_running_confirm(kwargs.get("print_opt")):
+                return
+            database_path: str | None = kwargs.pop("database_path", None)
+            db = Rekordbox6Database(path=database_path)  # ty: ignore[invalid-argument-type]
+            try:
+                return func(db=db, **kwargs)
+            finally:
+                db.close()
+
+        return wrapper
+
+    return decorator

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -1,11 +1,8 @@
 """Convert CLI command."""
 
 import logging
-import sys
 
 import click
-from pyrekordbox import Rekordbox6Database
-from pyrekordbox.utils import get_rekordbox_pid
 
 from rekordbox_edit._click import (
     PrintChoice,
@@ -24,6 +21,7 @@ from rekordbox_edit.cli._utils import (
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
+    with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
@@ -45,7 +43,8 @@ logger = logging.getLogger(__name__)
         track_ids_argument,
     ]
 )
-def convert_command(**kwargs):
+@with_database(writes=True)
+def convert_command(db, **kwargs):
     """Convert lossless audio files between formats and update RekordBox database.
 
     Supports conversion from any lossless format (FLAC, AIFF, WAV) to:
@@ -66,25 +65,6 @@ def convert_command(**kwargs):
     )
 
     scripting_mode = print_opt in SCRIPTING_MODES
-
-    rekordbox_pid = get_rekordbox_pid()
-    if rekordbox_pid:
-        if scripting_mode:
-            logger.error(
-                f"Rekordbox is running (PID {rekordbox_pid}). Cannot proceed in scripting mode."
-            )
-            sys.exit(1)
-        logger.warning(
-            f"Rekordbox is running (PID {rekordbox_pid}). Modifying the database while "
-            "Rekordbox is open can cause conflicts."
-        )
-        try:
-            if not confirm("Continue anyway?", default=False):
-                return
-        except UserQuit:
-            return
-
-    db = Rekordbox6Database()
 
     if yes or dry_run:
         response = convert(db, args, dry_run=dry_run)

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -3,7 +3,6 @@
 import logging
 
 import click
-from pyrekordbox import Rekordbox6Database
 
 from rekordbox_edit._click import (
     PrintChoice,
@@ -22,6 +21,7 @@ from rekordbox_edit.cli._utils import (
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
+    with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
@@ -47,7 +47,8 @@ logger = logging.getLogger(__name__)
     "field",
     type=click.Choice(list(FIELD_COLUMNS.keys()), case_sensitive=False),
 )
-def edit_command(**kwargs):
+@with_database(writes=True)
+def edit_command(db, **kwargs):
     """Edit a metadata field on tracks in the RekordBox database."""
     print_opt = kwargs.pop("print_opt", None)
     # CLI-only flags pulled out of kwargs before constructing EditArgs.
@@ -64,8 +65,6 @@ def edit_command(**kwargs):
         type("_S", (), {"dry_run": dry_run, "yes": yes})(),
         piped_stdin,
     )
-
-    db = Rekordbox6Database()
 
     if yes or dry_run:
         try:

--- a/rekordbox_edit/cli/search.py
+++ b/rekordbox_edit/cli/search.py
@@ -3,7 +3,6 @@
 import logging
 
 import click
-from pyrekordbox import Rekordbox6Database
 
 from rekordbox_edit._click import (
     PrintChoice,
@@ -17,6 +16,7 @@ from rekordbox_edit.cli._utils import (
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
+    with_database,
 )
 from rekordbox_edit.display import print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
@@ -29,14 +29,14 @@ logger = logging.getLogger(__name__)
     epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
 )
 @add_click_options([*global_click_filters, print_option, track_ids_argument])
-def search_command(**kwargs):
+@with_database()
+def search_command(db, **kwargs):
     """Search the RekordBox database."""
     print_opt = kwargs.pop("print_opt", None)
     args = SearchArgs(**kwargs)
     set_level(print_opt)
     _handle_stdin(args)
 
-    db = Rekordbox6Database()
     response = search(db, args)
 
     if print_opt is PrintChoice.SILENT:

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -40,8 +40,8 @@ def _response(tracks=None, converted=None, deleted=0, skipped=None, format_out="
 
 class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_yes_calls_convert_once(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response()
@@ -52,8 +52,8 @@ class TestConvertCommand:
         mock_convert.assert_called_once()
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_dry_run(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response()
@@ -67,8 +67,8 @@ class TestConvertCommand:
         assert mock_convert.call_args.kwargs.get("dry_run") is True
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_warns_already_target_skip(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -84,8 +84,8 @@ class TestConvertCommand:
         assert not any("--overwrite" in w for w in warnings)
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_warns_output_conflict_skip(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -100,8 +100,8 @@ class TestConvertCommand:
         assert any("--overwrite" in w for w in warnings)
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_logs_deleted_count(self, _pid, mock_db_class, mock_convert, mock_logger):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response(deleted=2)
@@ -110,13 +110,10 @@ class TestConvertCommand:
 
         mock_logger.info.assert_any_call("Deleted 2 original file(s)")
 
-    @patch("rekordbox_edit.cli.convert._handle_stdin", return_value=False)
-    @patch("rekordbox_edit.cli.convert.confirm")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345)
-    def test_rekordbox_running_user_declines(
-        self, _pid, mock_db_class, mock_confirm, _stdin
-    ):
+    @patch("rekordbox_edit.cli._utils.confirm")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
+    def test_rekordbox_running_user_declines(self, _pid, mock_db_class, mock_confirm):
         mock_confirm.return_value = False
 
         result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
@@ -124,9 +121,9 @@ class TestConvertCommand:
         assert result.exit_code == 0
         mock_db_class.assert_not_called()
 
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_aborts_in_scripting_mode_when_rekordbox_running(self, mock_db_class):
-        with patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345):
+        with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345):
             result = CliRunner().invoke(
                 convert_command,
                 ["--format-out", "aiff", "--yes", "--print", "silent"],
@@ -135,8 +132,8 @@ class TestConvertCommand:
         assert result.exit_code != 0
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_print_json_emits_envelope(self, _pid, mock_db_class, mock_convert):
         import json
 
@@ -154,8 +151,8 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.print_track_info")
     @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_previews_then_commits(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -172,8 +169,8 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.print_track_info")
     @patch("rekordbox_edit.cli.convert.confirm", return_value=False)
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_user_declines_skips_commit(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -189,8 +186,8 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.print_track_info")
     @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_user_quit_skips_commit(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -203,8 +200,8 @@ class TestConvertCommand:
         mock_convert.assert_called_once()  # preview only
 
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_empty_preview_exits_cleanly(
         self, _pid, mock_db_class, mock_convert
     ):
@@ -224,8 +221,8 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.print_track_info")
     @patch("rekordbox_edit.cli.convert.confirm")
     @patch("rekordbox_edit.cli.convert.convert")
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
     def test_interactive_narrows_to_confirmed_tracks(
         self, _pid, mock_db_class, mock_convert, mock_confirm, _print
     ):
@@ -251,12 +248,11 @@ class TestConvertCommand:
         narrowed_args = mock_convert.call_args_list[1].args[1]
         assert narrowed_args.track_ids == ["A"]
 
-    @patch("rekordbox_edit.cli.convert._handle_stdin", return_value=False)
-    @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
-    @patch("rekordbox_edit.cli.convert.Rekordbox6Database")
-    @patch("rekordbox_edit.cli.convert.get_rekordbox_pid", return_value=12345)
+    @patch("rekordbox_edit.cli._utils.confirm", return_value=True)
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
     def test_rekordbox_running_user_accepts_continues(
-        self, _pid, mock_db_class, _confirm, _stdin
+        self, _pid, mock_db_class, _confirm
     ):
         with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
             mock_db_class.return_value = Mock(session=Mock())

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -29,7 +29,7 @@ def _response(tracks=None, edits=None, skipped=None):
 
 class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_yes_calls_edit_once(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.return_value = _response()
@@ -44,7 +44,7 @@ class TestEditCommand:
         assert mock_edit.call_args.kwargs.get("dry_run", False) is False
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_dry_run_passes_flag_through(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.return_value = _response()
@@ -58,7 +58,7 @@ class TestEditCommand:
         assert mock_edit.call_args.kwargs.get("dry_run") is True
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_empty_result_exits_cleanly(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.return_value = _response(tracks=[], edits=[])
@@ -70,7 +70,7 @@ class TestEditCommand:
         assert result.exit_code == 0
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_value_error_becomes_usage_error(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = ValueError("Found 2 tracks that would be edited")
@@ -83,7 +83,7 @@ class TestEditCommand:
         assert "Error" in result.output
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_ids_outputs_ids(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         track = Track(ID="AAA", FileNameL="x.wav", FolderPath="/x.wav")
@@ -99,7 +99,7 @@ class TestEditCommand:
         assert "AAA" in result.output
 
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_json_outputs_envelope(self, mock_db_class, mock_edit):
         import json
 
@@ -121,7 +121,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_default_flow_previews_then_commits(
         self, mock_db_class, mock_edit, mock_confirm, _print
     ):
@@ -138,7 +138,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm", return_value=False)
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_default_flow_user_declines_skips_commit(
         self, mock_db_class, mock_edit, mock_confirm, _print
     ):
@@ -154,7 +154,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_default_flow_user_quit_skips_commit(
         self, mock_db_class, mock_edit, _print, _confirm
     ):
@@ -168,7 +168,7 @@ class TestEditCommand:
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_default_flow_empty_preview_exits_cleanly(
         self, mock_db_class, mock_edit, _print
     ):
@@ -186,7 +186,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm")
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_interactive_narrows_to_confirmed_tracks(
         self, mock_db_class, mock_edit, mock_confirm, _print
     ):
@@ -215,7 +215,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)
     @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli.edit.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_interactive_user_quit_skips_commit(
         self, mock_db_class, mock_edit, _confirm, _print
     ):

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -22,7 +22,7 @@ def _response(*tracks):
 class TestSearchCommand:
     @patch("rekordbox_edit.cli.search.print_track_info")
     @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_calls_print_track_info_by_default(
         self, mock_db_class, mock_search, mock_print, make_track
     ):
@@ -35,7 +35,7 @@ class TestSearchCommand:
         mock_print.assert_called_once()
 
     @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_ids(self, mock_db_class, mock_search, make_track):
         mock_db_class.return_value = Mock(session=Mock())
         mock_search.return_value = _response(make_track(ID="A"), make_track(ID="B"))
@@ -46,7 +46,7 @@ class TestSearchCommand:
         assert "A B" in result.output
 
     @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_json_emits_envelope(self, mock_db_class, mock_search, make_track):
         import json
 
@@ -60,7 +60,7 @@ class TestSearchCommand:
         assert payload["tracks"][0]["ID"] == "A"
 
     @patch("rekordbox_edit.cli.search.search")
-    @patch("rekordbox_edit.cli.search.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_silent_produces_no_output(
         self, mock_db_class, mock_search, make_track
     ):


### PR DESCRIPTION
Pyrekrodbox let's you specify a custom path at which to look for the database file. This integrates with that feature.