### PR TITLE
BREAKING(convert): replace --delete/--keep with --delete-originals enum

### DIFF
--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -4,18 +4,18 @@ Convert audio files between formats and update the Rekordbox database to point a
 
 ## Supported Formats
 
-- **Input:** FLAC, AIFF, WAV (hi-res only — lossy-compressed sources are skipped)
+- **Input:** FLAC, AIFF, WAV (hi-res formats only — lossy-compressed sources are skipped)
 - **Output:** AIFF (default), FLAC, WAV, or MP3 (320kbps CBR)
 
 Tracks already in the target format are skipped, as are tracks whose output file already exists (override with `--overwrite`).
 
 ## Bit Depth and Sample Rate
 
-Lossless conversions target **16-bit / 44.1 kHz**:
+All conversions target **16-bit / 44.1 kHz**, with a few nuances:
 
 - A source already at the target bit depth and sample rate converts losslessly.
 - A higher-resolution source (say 24-bit or 96 kHz) is down-sampled to the target, and is considered **lossy** even between lossless formats.
-- A source below the target keeps its own sample rate: up-sampling cannot restore resolution the file never had.
+- Other than conversion to MP3, which always encode to 44.1 kHz, a source with a lower sample rate than the target fidelity keeps its original sample rate.
 
 ## Originals: Delete or Keep
 
@@ -49,7 +49,7 @@ rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
 
 ### Guardrails
 - Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- Editing while Rekordbox is open risks corrupting your database. By default `convert` warns; in a non-interactive mode (e.g. `--print ids`) it throws an error.
+- Editing while Rekordbox is open risks corrupting your database. By default `convert` warns and asks for confirmation (defaulting to no, so a `--yes` would exit); in a non-interactive mode (e.g. `--print ids`) it throws an error.
 
 ## Reference
 

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -4,14 +4,18 @@ Convert audio files between formats and update the Rekordbox database to point a
 
 ## Supported Formats
 
-- **Input:** FLAC, AIFF, WAV (lossless only — lossy sources are skipped)
-- **Output:** AIFF (default), FLAC, WAV, ALAC, or MP3 (320kbps CBR)
+- **Input:** FLAC, AIFF, WAV (hi-res only — lossy-compressed sources are skipped)
+- **Output:** AIFF (default), FLAC, WAV, or MP3 (320kbps CBR)
 
 Tracks already in the target format are skipped, as are tracks whose output file already exists (override with `--overwrite`).
 
 ## Originals: Delete or Keep
 
-After a successful conversion the original file is **deleted** for lossless output (you can always convert back) and **kept** for MP3 output (the quality loss is one-way). Override either default with `--delete` or `--keep`.
+`--delete-originals` controls what happens to the source file after a successful conversion:
+
+- `lossless` (default) — delete the original when converting to a hi-res format (you can always convert back); keep it when converting to MP3 (the quality loss is one-way)
+- `all` — always delete the original
+- `none` — never delete the original
 
 ## Examples
 
@@ -23,10 +27,10 @@ rbe convert --format-out aiff --format flac --dry-run
 rbe convert --format-out wav --artist "Burial" --yes
 
 # Convert to MP3 but delete originals
-rbe convert --format-out mp3 --playlist "Export" --yes --delete
+rbe convert --format-out mp3 --playlist "Export" --yes --delete-originals all
 
 # Keep originals when converting to AIFF
-rbe convert --format-out aiff --format flac --yes --keep
+rbe convert --format-out aiff --format flac --yes --delete-originals none
 
 # Get just the IDs of files that would be converted
 rbe convert --format-out aiff --format flac --print ids --dry-run

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -9,11 +9,19 @@ Convert audio files between formats and update the Rekordbox database to point a
 
 Tracks already in the target format are skipped, as are tracks whose output file already exists (override with `--overwrite`).
 
+## Bit Depth and Sample Rate
+
+Lossless conversions target **16-bit / 44.1 kHz**:
+
+- A source already at the target bit depth and sample rate converts losslessly.
+- A higher-resolution source (say 24-bit or 96 kHz) is down-sampled to the target, and is considered **lossy** even between lossless formats.
+- A source below the target keeps its own sample rate: up-sampling cannot restore resolution the file never had.
+
 ## Originals: Delete or Keep
 
 `--delete-originals` controls what happens to the source file after a successful conversion:
 
-- `lossless` (default) — delete the original when converting to a hi-res format (you can always convert back); keep it when converting to MP3 (the quality loss is one-way)
+- `lossless` (default) — delete the original only when the conversion lost no audio information; keep it when the conversion was lossy (MP3 output or down-sampled hi-res output)
 - `all` — always delete the original
 - `none` — never delete the original
 

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -161,7 +161,7 @@ convert_click_options = [
         "--delete-originals",
         type=click.Choice(["none", "lossless", "all"], case_sensitive=False),
         default="lossless",
-        help="When to delete original files after conversion: 'lossless' deletes them only when converting to a hi-res format, 'all' always deletes them, 'none' never deletes them (default: lossless)",
+        help="When to delete original files after conversion: 'lossless' deletes them only when no audio information was lost (down-sampling and MP3 output count as lossy), 'all' always deletes them, 'none' never deletes them (default: lossless)",
     ),
     click.option(
         "--overwrite",

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -158,9 +158,10 @@ edit_click_options = [
 
 convert_click_options = [
     click.option(
-        "--delete/--keep",
-        default=None,
-        help="Delete or keep original files after conversion (default: delete for lossless, keep for MP3)",
+        "--delete-originals",
+        type=click.Choice(["none", "lossless", "all"], case_sensitive=False),
+        default="lossless",
+        help="When to delete original files after conversion: 'lossless' deletes them only when converting to a hi-res format, 'all' always deletes them, 'none' never deletes them (default: lossless)",
     ),
     click.option(
         "--overwrite",
@@ -169,7 +170,7 @@ convert_click_options = [
     ),
     click.option(
         "--format-out",
-        type=click.Choice(["aiff", "flac", "wav", "alac", "mp3"], case_sensitive=False),
+        type=click.Choice(["aiff", "flac", "wav", "mp3"], case_sensitive=False),
         default="aiff",
         help="Output format (default: aiff)",
     ),

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -300,12 +300,12 @@ def convert(
 
     assert db.session is not None
 
-    should_delete = (
-        args.delete if args.delete is not None else args.format_out.upper() != "MP3"
+    should_delete = args.delete_originals == "all" or (
+        args.delete_originals == "lossless" and args.format_out.upper() != "MP3"
     )
     logger.debug(
         f"convert should_delete={should_delete} "
-        f"(args.delete={args.delete}, format_out={args.format_out})"
+        f"(delete_originals={args.delete_originals}, format_out={args.format_out})"
     )
 
     # content_map enables per-op live FolderPath / FileNameL reads in the loop.

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -122,7 +122,8 @@ def _convert_to_hi_res(input_path, output_path, output_format, sample_rate):
 
 
 def _convert_to_mp3(input_path, mp3_path):
-    """Convert hi-res file to MP3 320kbps CBR."""
+    """Convert hi-res file to MP3 320kbps CBR at the target bit depth and
+    sample rate."""
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
     if not ffmpeg_in_path():
@@ -135,6 +136,10 @@ def _convert_to_mp3(input_path, mp3_path):
                 mp3_path,
                 acodec="libmp3lame",
                 audio_bitrate="320k",
+                ar=TARGET_SAMPLE_RATE,
+                # libmp3lame takes planar input; s16p quantizes to 16-bit
+                # before encoding.
+                sample_fmt="s16p",
                 map_metadata=0,
                 write_id3v2=1,
             )
@@ -261,10 +266,12 @@ def _classify_convert(content, args: ConvertRequest) -> ConvertOp | SkippedTrack
             f"skip convert id={content.ID} reason=output_file_exists path={output_path}"
         )
         return SkippedTrack(id=str(content.ID), reason="output_file_exists")
-    mp3_out = args.format_out.upper() == "MP3"
     # The DB SampleRate stands in for the probe here so dry-run previews match;
-    # the convert loop re-probes and reconciles.
-    output_sample_rate = None if mp3_out else _effective_sample_rate(content.SampleRate)
+    # the convert loop re-probes and reconciles. MP3 always encodes at the target.
+    if args.format_out.upper() == "MP3":
+        output_sample_rate = TARGET_SAMPLE_RATE
+    else:
+        output_sample_rate = _effective_sample_rate(content.SampleRate)
     return ConvertOp(
         id=str(content.ID),
         source_path=content.FolderPath or "",
@@ -277,7 +284,7 @@ def _classify_convert(content, args: ConvertRequest) -> ConvertOp | SkippedTrack
         source_bit_depth=content.BitDepth,
         source_sample_rate=content.SampleRate,
         output_file_type=args.format_out.upper(),
-        output_bit_depth=None if mp3_out else TARGET_BIT_DEPTH,
+        output_bit_depth=TARGET_BIT_DEPTH,
         output_sample_rate=output_sample_rate,
     )
 
@@ -362,7 +369,7 @@ def convert(
                 raise RuntimeError(f"Source not found: {src}")
 
             if args.format_out.upper() == "MP3":
-                output_sample_rate = None
+                output_sample_rate = TARGET_SAMPLE_RATE
                 success = _convert_to_mp3(src, op.output_path)
             else:
                 fidelity, output_sample_rate = _classify_source_fidelity(src)

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -26,6 +26,7 @@ from rekordbox_edit.utils import (
     get_audio_info,
     get_extension_for_format,
     get_file_type_for_format,
+    get_file_type_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -255,10 +256,24 @@ def _classify_convert(content, args: ConvertRequest) -> ConvertOp | SkippedTrack
             f"skip convert id={content.ID} reason=output_file_exists path={output_path}"
         )
         return SkippedTrack(id=str(content.ID), reason="output_file_exists")
+    mp3_out = args.format_out.upper() == "MP3"
+    # The DB SampleRate stands in for the probe here so dry-run previews match;
+    # the convert loop re-probes and reconciles.
+    output_sample_rate = None if mp3_out else _effective_sample_rate(content.SampleRate)
     return ConvertOp(
         id=str(content.ID),
         source_path=content.FolderPath or "",
         output_path=output_path,
+        source_file_type=(
+            get_file_type_name(content.FileType)
+            if content.FileType is not None
+            else None
+        ),
+        source_bit_depth=content.BitDepth,
+        source_sample_rate=content.SampleRate,
+        output_file_type=args.format_out.upper(),
+        output_bit_depth=None if mp3_out else TARGET_BIT_DEPTH,
+        output_sample_rate=output_sample_rate,
     )
 
 
@@ -342,6 +357,7 @@ def convert(
                 raise RuntimeError(f"Source not found: {src}")
 
             if args.format_out.upper() == "MP3":
+                output_sample_rate = None
                 success = _convert_to_mp3(src, op.output_path)
             else:
                 fidelity, output_sample_rate = _classify_source_fidelity(src)
@@ -367,7 +383,12 @@ def convert(
                 args.format_out.upper(),
             )
             converted_ops.append(
-                ConvertOp(id=op.id, source_path=src, output_path=op.output_path)
+                op.model_copy(
+                    update={
+                        "source_path": src,
+                        "output_sample_rate": output_sample_rate,
+                    }
+                )
             )
 
         db.session.commit()

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -4,7 +4,7 @@ import logging
 import os
 import posixpath
 from pathlib import Path
-from typing import Tuple
+from typing import Literal, Tuple
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
@@ -30,47 +30,80 @@ from rekordbox_edit.utils import (
 
 logger = logging.getLogger(__name__)
 
+TARGET_BIT_DEPTH = 16
+TARGET_SAMPLE_RATE = 44100
+
+_HI_RES_CODECS = {
+    "aiff": "pcm_s16be",
+    "wav": "pcm_s16le",
+    "flac": "flac",
+}
+
 
 # ── ffmpeg helpers ────────────────────────────────────────────────────────
 
 
-def _convert_to_lossless(input_path, output_path, output_format):
-    """Convert lossless file to another lossless format, preserving bit depth."""
+def _effective_sample_rate(source_rate: int | None) -> int:
+    """The output sample rate for a conversion: the target, clamped to the
+    source rate so a conversion never up-samples."""
+    if source_rate and source_rate < TARGET_SAMPLE_RATE:
+        return source_rate
+    return TARGET_SAMPLE_RATE
+
+
+def _classify_source_fidelity(
+    source_path,
+) -> Tuple[Literal["lossless", "lossy"], int]:
+    """Probe a source file and return the conversion's fidelity along with
+    its effective sample rate. "lossless" means no audio information is lost:
+    the source is at the target bit depth and at or below the target sample
+    rate. An unknown bit depth counts as lossy so originals are kept when in
+    doubt.
+    """
+    audio_info = get_audio_info(source_path)
+    bit_depth = audio_info["bit_depth"]
+    sample_rate = audio_info["sample_rate"]
+    logger.debug(
+        f"Source audio: bit_depth={bit_depth}, sample_rate={sample_rate}, "
+        f"channels={audio_info.get('channels')}"
+    )
+    effective_rate = _effective_sample_rate(sample_rate)
+    if bit_depth == TARGET_BIT_DEPTH and sample_rate == effective_rate:
+        return "lossless", effective_rate
+    return "lossy", effective_rate
+
+
+def _convert_to_hi_res(input_path, output_path, output_format, sample_rate):
+    """Convert a hi-res file to another hi-res format at the target bit
+    depth and the given sample rate, down-sampling higher-resolution
+    sources."""
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
     if not ffmpeg_in_path():
         raise Exception(f"FFmpeg not found in PATH.{get_ffmpeg_directions()}")
 
-    audio_info = get_audio_info(input_path)
-    bit_depth = audio_info["bit_depth"]
-    logger.debug(
-        f"Source audio: bit_depth={bit_depth}, sample_rate={audio_info.get('sample_rate')}, channels={audio_info.get('channels')}"
-    )
+    codec = _HI_RES_CODECS.get(output_format.value)
+    if codec is None:
+        raise Exception(f"Unsupported hi-res format: {output_format}")
 
-    codec_maps = {
-        "aiff": {16: "pcm_s16be", 24: "pcm_s24be", 32: "pcm_s32be"},
-        "wav": {16: "pcm_s16le", 24: "pcm_s24le", 32: "pcm_s32le"},
-        "flac": None,
+    output_kwargs = {
+        "acodec": codec,
+        "ar": sample_rate,
+        "map_metadata": 0,
+        "write_id3v2": 1,
     }
+    # PCM codecs fix the bit depth by name; the flac encoder needs it spelled out.
+    if output_format.value == "flac":
+        output_kwargs["sample_fmt"] = "s16"
 
-    if output_format.value not in codec_maps:
-        raise Exception(f"Unsupported lossless format: {output_format}")
-
-    codec_map = codec_maps[output_format.value]
-    if codec_map is None:
-        codec = output_format.value
-    elif bit_depth in codec_map:
-        codec = codec_map[bit_depth]
-    else:
-        codec = list(codec_map.values())[0]
-        logger.debug(f"bit_depth={bit_depth} not in codec map, falling back to {codec}")
-
-    logger.debug(f"Selected codec: {codec} (bit_depth={bit_depth})")
+    logger.debug(
+        f"Selected codec: {codec} targeting {TARGET_BIT_DEPTH}-bit/{sample_rate} Hz"
+    )
 
     try:
         (
             ffmpeg.input(input_path)
-            .output(output_path, acodec=codec, map_metadata=0, write_id3v2=1)
+            .output(output_path, **output_kwargs)
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
@@ -88,7 +121,7 @@ def _convert_to_lossless(input_path, output_path, output_format):
 
 
 def _convert_to_mp3(input_path, mp3_path):
-    """Convert lossless file to MP3 320kbps CBR."""
+    """Convert hi-res file to MP3 320kbps CBR."""
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
     if not ffmpeg_in_path():
@@ -142,16 +175,11 @@ def _update_database_record(
 
     if output_format.upper() in ["AIFF", "FLAC", "WAV"]:
         converted_bit_depth = converted_audio_info["bit_depth"]
-        database_bit_depth = getattr(content, "BitDepth", None)
-        if (
-            database_bit_depth
-            and converted_bit_depth
-            and converted_bit_depth != database_bit_depth
-        ):
-            raise Exception(
-                f"Bit depth mismatch for lossless transcode: "
-                f"database={database_bit_depth}, file={converted_bit_depth}"
-            )
+        if converted_bit_depth:
+            content.BitDepth = converted_bit_depth
+        converted_sample_rate = converted_audio_info["sample_rate"]
+        if converted_sample_rate:
+            content.SampleRate = converted_sample_rate
 
     content.FileNameL = new_filename
     content.FolderPath = converted_full_path
@@ -300,17 +328,10 @@ def convert(
 
     assert db.session is not None
 
-    should_delete = args.delete_originals == "all" or (
-        args.delete_originals == "lossless" and args.format_out.upper() != "MP3"
-    )
-    logger.debug(
-        f"convert should_delete={should_delete} "
-        f"(delete_originals={args.delete_originals}, format_out={args.format_out})"
-    )
-
     # content_map enables per-op live FolderPath / FileNameL reads in the loop.
     content_map = {str(c.ID): c for c in contents}
     converted_ops: list[ConvertOp] = []
+    lossless_op_ids: set[str] = set()
     try:
         for i, op in enumerate(ops, 1):
             content = content_map[op.id]
@@ -323,8 +344,14 @@ def convert(
             if args.format_out.upper() == "MP3":
                 success = _convert_to_mp3(src, op.output_path)
             else:
-                success = _convert_to_lossless(
-                    src, op.output_path, OutputFormats(args.format_out.lower())
+                fidelity, output_sample_rate = _classify_source_fidelity(src)
+                if fidelity == "lossless":
+                    lossless_op_ids.add(op.id)
+                success = _convert_to_hi_res(
+                    src,
+                    op.output_path,
+                    OutputFormats(args.format_out.lower()),
+                    output_sample_rate,
                 )
 
             if not success:
@@ -355,15 +382,32 @@ def convert(
         _rollback_and_cleanup(db, converted_ops)
         raise
 
+    if args.delete_originals == "all":
+        deletable_ops = converted_ops
+    elif args.delete_originals == "lossless":
+        deletable_ops = [op for op in converted_ops if op.id in lossless_op_ids]
+    else:
+        deletable_ops = []
+    logger.debug(
+        f"convert delete_originals={args.delete_originals}: deleting "
+        f"{len(deletable_ops)}/{len(converted_ops)} source file(s)"
+    )
+
     deleted = 0
-    if should_delete:
-        for op in converted_ops:
-            try:
-                os.remove(op.source_path)
-                deleted += 1
-            except Exception as e:
-                logger.warning(f"Failed to delete {op.source_path}: {e}")
-        logger.debug(f"convert deleted {deleted}/{len(converted_ops)} source file(s)")
+    for op in deletable_ops:
+        try:
+            os.remove(op.source_path)
+            deleted += 1
+        except Exception as e:
+            logger.warning(f"Failed to delete {op.source_path}: {e}")
+
+    kept = len(converted_ops) - len(deletable_ops)
+    if (
+        args.delete_originals == "lossless"
+        and kept
+        and args.format_out.upper() != "MP3"
+    ):
+        logger.info(f"Kept {kept} original file(s) whose conversion was lossy")
 
     converted_ids = [op.id for op in converted_ops]
     try:

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -174,13 +174,18 @@ def _update_database_record(
     if not file_type:
         raise Exception(f"Unsupported output format: {output_format}")
 
-    if output_format.upper() in ["AIFF", "FLAC", "WAV"]:
+    converted_sample_rate = converted_audio_info["sample_rate"]
+    if converted_sample_rate:
+        content.SampleRate = converted_sample_rate
+
+    if output_format.upper() == "MP3":
+        # Rekordbox records MP3s as 16-bit (see the e2e DB fixtures); probes
+        # report no bit depth for them.
+        content.BitDepth = 16
+    else:
         converted_bit_depth = converted_audio_info["bit_depth"]
         if converted_bit_depth:
             content.BitDepth = converted_bit_depth
-        converted_sample_rate = converted_audio_info["sample_rate"]
-        if converted_sample_rate:
-            content.SampleRate = converted_sample_rate
 
     content.FileNameL = new_filename
     content.FolderPath = converted_full_path

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -46,10 +46,10 @@ logger = logging.getLogger(__name__)
 )
 @with_database(writes=True)
 def convert_command(db, **kwargs):
-    """Convert lossless audio files between formats and update RekordBox database.
+    """Convert hi-res audio files between formats and update RekordBox database.
 
-    Supports conversion from any lossless format (FLAC, AIFF, WAV) to:
-    AIFF, FLAC, WAV, ALAC, or MP3. Skips lossy formats and files already in
+    Supports conversion from any hi-res format (FLAC, AIFF, WAV) to:
+    AIFF, FLAC, WAV, or MP3. Skips lossy formats and files already in
     the target format.
     """
     print_opt = kwargs.pop("print_opt", None)

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -51,6 +51,10 @@ def convert_command(db, **kwargs):
     Supports conversion from any hi-res format (FLAC, AIFF, WAV) to:
     AIFF, FLAC, WAV, or MP3. Skips lossy formats and files already in
     the target format.
+
+    Lossless conversions target 16-bit/44.1 kHz: higher-resolution sources
+    are down-sampled, and sources below the target keep their own sample
+    rate rather than being up-sampled.
     """
     print_opt = kwargs.pop("print_opt", None)
     dry_run = kwargs.pop("dry_run", False)

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -84,7 +84,8 @@ class ConvertRequest(FilterArgs):
     delete_originals: DeleteOriginalsMode = "lossless"
     """When to delete original files after conversion: "all" always deletes
     them, "none" never deletes them, and "lossless" (the default) deletes them
-    only when converting to a hi-res format."""
+    only when the conversion loses no audio information. Down-sampling to the
+    conversion target counts as lossy, as does MP3 output."""
     overwrite: bool = False
 
 

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -149,8 +149,9 @@ class EditOp(BaseModel):
 class ConvertOp(BaseModel):
     """A planned or performed conversion: track ID, source/output paths, and
     the file type, bit depth, and sample rate on each side. Source audio
-    fields mirror the database record; MP3 output leaves bit depth and sample
-    rate to the encoder, so those stay None."""
+    fields mirror the database record; output fields reflect the conversion
+    target, with the sample rate clamped to the source so a conversion never
+    up-samples."""
 
     id: str
     source_path: str

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -147,11 +147,20 @@ class EditOp(BaseModel):
 
 
 class ConvertOp(BaseModel):
-    """A planned or performed conversion: track ID + source/output paths."""
+    """A planned or performed conversion: track ID, source/output paths, and
+    the file type, bit depth, and sample rate on each side. Source audio
+    fields mirror the database record; MP3 output leaves bit depth and sample
+    rate to the encoder, so those stay None."""
 
     id: str
     source_path: str
     output_path: str
+    source_file_type: str | None = None
+    source_bit_depth: int | None = None
+    source_sample_rate: int | None = None
+    output_file_type: str | None = None
+    output_bit_depth: int | None = None
+    output_sample_rate: int | None = None
 
 
 # ── Response envelopes ────────────────────────────────────────────────────

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -74,14 +74,17 @@ class EditRequest(FilterArgs):
     multi: bool = False
 
 
+DeleteOriginalsMode: TypeAlias = Literal["none", "lossless", "all"]
+
+
 class ConvertRequest(FilterArgs):
     """Inputs for convert(): the shared track filters plus output format and original-file handling."""
 
     format_out: str = "aiff"
-    delete: bool | None = None
-    """Whether to delete the original files after conversion: True deletes them,
-    False keeps them, and None applies the per-format default (delete for
-    lossless output, keep for MP3)."""
+    delete_originals: DeleteOriginalsMode = "lossless"
+    """When to delete original files after conversion: "all" always deletes
+    them, "none" never deletes them, and "lossless" (the default) deletes them
+    only when converting to a hi-res format."""
     overwrite: bool = False
 
 

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -54,7 +54,6 @@ def get_extension_for_format(format_name: str):
         "AIFF": ".aiff",
         "FLAC": ".flac",
         "WAV": ".wav",
-        "ALAC": ".m4a",
     }
     extension = _get_extension_for_format.get(format_name.upper())
     if extension is None:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -69,6 +69,23 @@ class TestClassifyConvert:
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_mp3_output_ignores_source_sample_rate(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.mp3", "out.mp3", "/")
+        content = make_djmd_content_item(ID="7", FileType=11, SampleRate=22050)
+
+        result = _classify_convert(content, ConvertRequest(format_out="mp3"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.output_sample_rate == 44100
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     def test_missing_db_fields_default_to_target(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
     ):
@@ -173,7 +190,7 @@ class TestClassifyConvert:
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_mp3_output_audio_fields_left_to_encoder(
+    def test_mp3_output_targets_conversion_default(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
     ):
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
@@ -186,8 +203,8 @@ class TestClassifyConvert:
 
         assert isinstance(result, ConvertOp)
         assert result.output_file_type == "MP3"
-        assert result.output_bit_depth is None
-        assert result.output_sample_rate is None
+        assert result.output_bit_depth == 16
+        assert result.output_sample_rate == 44100
 
 
 def _seed_db(mock_db, *contents):
@@ -1102,6 +1119,21 @@ class TestConvertToMp3:
         result = _convert_to_mp3("in.flac", "out.mp3")
 
         assert result is True
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_encodes_at_conversion_target(self, mock_ffmpeg, _):
+        mock_input = Mock()
+        mock_ffmpeg.input.return_value = mock_input
+        mock_output = mock_input.output.return_value
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        _convert_to_mp3("in.flac", "out.mp3")
+
+        _, kwargs = mock_input.output.call_args
+        assert kwargs["ar"] == 44100
+        assert kwargs["sample_fmt"] == "s16p"
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_ffmpeg_not_found_raises(self, _):

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1205,7 +1205,11 @@ class TestUpdateDatabaseRecord:
         mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123)
         mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": 320, "bit_depth": 16}
+        mock_get_audio_info.return_value = {
+            "bitrate": 320,
+            "bit_depth": None,
+            "sample_rate": 44100,
+        }
 
         _update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
 
@@ -1218,11 +1222,33 @@ class TestUpdateDatabaseRecord:
         mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123)
         mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": None, "bit_depth": 16}
+        mock_get_audio_info.return_value = {
+            "bitrate": None,
+            "bit_depth": None,
+            "sample_rate": 44100,
+        }
 
         _update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
 
         assert mock_content.BitRate == 320
+
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_mp3_output_updates_bit_depth_and_sample_rate(
+        self, mock_get_audio_info, make_djmd_content_item
+    ):
+        mock_db = Mock()
+        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
+        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
+        mock_get_audio_info.return_value = {
+            "bitrate": 320,
+            "bit_depth": None,
+            "sample_rate": 48000,
+        }
+
+        _update_database_record(mock_db, 123, "output.mp3", "/path/to", "MP3")
+
+        assert mock_content.BitDepth == 16
+        assert mock_content.SampleRate == 48000
 
     def test_content_not_found_raises(self):
         mock_db = Mock()

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -52,7 +52,7 @@ class TestClassifyConvert:
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
-    def test_below_target_source_converts(
+    def test_below_target_sample_rate_clamps_to_source(
         self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
     ):
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
@@ -64,6 +64,27 @@ class TestClassifyConvert:
         result = _classify_convert(content, ConvertRequest(format_out="aiff"))
 
         assert isinstance(result, ConvertOp)
+        assert result.output_sample_rate == 22050
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_missing_db_fields_default_to_target(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(
+            ID="8", FileType=11, BitDepth=None, SampleRate=None
+        )
+
+        result = _classify_convert(content, ConvertRequest(format_out="aiff"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.output_bit_depth == 16
+        assert result.output_sample_rate == 44100
 
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -124,6 +145,49 @@ class TestClassifyConvert:
         assert result.id == "4"
         assert result.source_path == "/music/song.wav"
         assert result.output_path == "/music/song.aif"
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_populates_audio_fields(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/music/song.aif", "song.aif", "/music")
+        content = make_djmd_content_item(
+            ID="4", FileType=11, BitDepth=24, SampleRate=96000
+        )
+
+        result = _classify_convert(content, ConvertRequest(format_out="aiff"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.source_file_type == "WAV"
+        assert result.source_bit_depth == 24
+        assert result.source_sample_rate == 96000
+        assert result.output_file_type == "AIFF"
+        assert result.output_bit_depth == 16
+        assert result.output_sample_rate == 44100
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_mp3_output_audio_fields_left_to_encoder(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/music/song.mp3", "song.mp3", "/music")
+        content = make_djmd_content_item(ID="7", FileType=11)
+
+        result = _classify_convert(content, ConvertRequest(format_out="mp3"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.output_file_type == "MP3"
+        assert result.output_bit_depth is None
+        assert result.output_sample_rate is None
 
 
 def _seed_db(mock_db, *contents):
@@ -255,7 +319,14 @@ class TestConvertRealRun:
         )
         mock_update.assert_called_once()
         mock_db.session.commit.assert_called_once()
-        assert response.result.converted[0].id == "1"
+        op = response.result.converted[0]
+        assert op.id == "1"
+        assert op.source_file_type == "WAV"
+        assert op.source_bit_depth == 16
+        assert op.source_sample_rate == 44100
+        assert op.output_file_type == "AIFF"
+        assert op.output_bit_depth == 16
+        assert op.output_sample_rate == 44100
         assert response.result.deleted == 0
         assert response.tracks[0].ID == "1"
 
@@ -458,7 +529,8 @@ class TestConvertRealRun:
         make_djmd_content_item,
     ):
         # DB fields say 16/44.1 but the probe reveals a 22.05 kHz source: the
-        # conversion keeps the source rate instead of up-sampling.
+        # conversion keeps the source rate instead of up-sampling, and the op
+        # reports the rate that was actually encoded.
         mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
             fmt.upper(), 99
         )
@@ -472,7 +544,8 @@ class TestConvertRealRun:
         mock_hi_res.assert_called_once_with(
             "/in.wav", "/out.aif", OutputFormats.AIFF, 22050
         )
-        assert len(response.result.converted) == 1
+        op = response.result.converted[0]
+        assert op.output_sample_rate == 22050
         assert response.result.skipped == []
 
     @patch("rekordbox_edit.api.convert.os.remove")

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -224,7 +224,8 @@ class TestConvertRealRun:
         _seed_db(mock_db, content)  # post-commit re-query returns the same row
 
         response = convert(
-            mock_db, ConvertRequest(format_out="aiff", delete=False, overwrite=True)
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
         )
 
         mock_lossless.assert_called_once_with("/in.wav", "/out.aif", OutputFormats.AIFF)
@@ -242,7 +243,7 @@ class TestConvertRealRun:
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
-    def test_deletes_originals_when_should_delete_true(
+    def test_deletes_originals_when_mode_all(
         self,
         mock_gfc,
         mock_get_type,
@@ -264,7 +265,8 @@ class TestConvertRealRun:
         _seed_db(mock_db, content)
 
         response = convert(
-            mock_db, ConvertRequest(format_out="aiff", delete=True, overwrite=True)
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="all", overwrite=True),
         )
 
         mock_remove.assert_called_once_with("/in.wav")
@@ -336,7 +338,10 @@ class TestConvertRealRun:
 
         with pytest.raises(KeyboardInterrupt):
             convert(
-                mock_db, ConvertRequest(format_out="aiff", delete=True, overwrite=True)
+                mock_db,
+                ConvertRequest(
+                    format_out="aiff", delete_originals="all", overwrite=True
+                ),
             )
 
         mock_db.session.commit.assert_called_once()
@@ -380,7 +385,8 @@ class TestConvertRealRun:
         _seed_db(mock_db, contents[2], contents[0], contents[1])
 
         response = convert(
-            mock_db, ConvertRequest(format_out="aiff", delete=False, overwrite=True)
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
         )
 
         assert [op.id for op in response.result.converted] == ["A", "B", "C"]
@@ -415,7 +421,8 @@ class TestConvertRealRun:
         mock_db.session.execute.side_effect = RuntimeError("post-commit query failed")
 
         response = convert(
-            mock_db, ConvertRequest(format_out="aiff", delete=False, overwrite=True)
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
         )
 
         # Commit happened
@@ -559,7 +566,7 @@ class TestConvertRealRun:
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
-    def test_skips_deletion_when_should_delete_false(
+    def test_skips_deletion_when_mode_none(
         self,
         mock_gfc,
         mock_get_type,
@@ -581,7 +588,8 @@ class TestConvertRealRun:
         _seed_db(mock_db, content)
 
         response = convert(
-            mock_db, ConvertRequest(format_out="aiff", delete=False, overwrite=True)
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
         )
 
         mock_remove.assert_not_called()

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -6,8 +6,9 @@ import pytest
 
 from rekordbox_edit.api.convert import (
     _classify_convert,
+    _classify_source_fidelity,
     _cleanup_converted_files,
-    _convert_to_lossless,
+    _convert_to_hi_res,
     _convert_to_mp3,
     _get_output_path,
     _rollback_and_cleanup,
@@ -47,6 +48,22 @@ class TestClassifyConvert:
 
         assert isinstance(result, SkippedTrack)
         assert result.reason == "already_target_format"
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    def test_below_target_source_converts(
+        self, mock_get_type, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="6", FileType=11, SampleRate=22050)
+
+        result = _classify_convert(content, ConvertRequest(format_out="aiff"))
+
+        assert isinstance(result, ConvertOp)
 
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -196,22 +213,27 @@ class TestConvertRealRun:
         assert response.tracks == []
         mock_db.session.commit.assert_not_called()
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
-    def test_successful_lossless_commits(
+    def test_successful_hi_res_commits(
         self,
         mock_gfc,
         mock_get_type,
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_update,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -228,16 +250,22 @@ class TestConvertRealRun:
             ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
         )
 
-        mock_lossless.assert_called_once_with("/in.wav", "/out.aif", OutputFormats.AIFF)
+        mock_hi_res.assert_called_once_with(
+            "/in.wav", "/out.aif", OutputFormats.AIFF, 44100
+        )
         mock_update.assert_called_once()
         mock_db.session.commit.assert_called_once()
         assert response.result.converted[0].id == "1"
         assert response.result.deleted == 0
         assert response.tracks[0].ID == "1"
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -250,9 +278,10 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_update,
         mock_remove,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -272,8 +301,225 @@ class TestConvertRealRun:
         mock_remove.assert_called_once_with("/in.wav")
         assert response.result.deleted == 1
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossy", 44100),
+    )
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_lossless_mode_keeps_originals_from_lossy_conversion(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_hi_res,
+        mock_update,
+        mock_remove,
+        _fidelity,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(
+            mock_db,
+            ConvertRequest(
+                format_out="aiff", delete_originals="lossless", overwrite=True
+            ),
+        )
+
+        mock_hi_res.assert_called_once()
+        mock_remove.assert_not_called()
+        assert response.result.deleted == 0
+        assert len(response.result.converted) == 1
+
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossy", 44100),
+    )
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_all_mode_deletes_originals_from_lossy_conversion(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_hi_res,
+        mock_update,
+        mock_remove,
+        _fidelity,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="all", overwrite=True),
+        )
+
+        mock_remove.assert_called_once_with("/in.wav")
+        assert response.result.deleted == 1
+
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_lossless_mode_deletes_originals_from_lossless_conversion(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_hi_res,
+        mock_update,
+        mock_remove,
+        _fidelity,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(
+            mock_db,
+            ConvertRequest(
+                format_out="aiff", delete_originals="lossless", overwrite=True
+            ),
+        )
+
+        mock_remove.assert_called_once_with("/in.wav")
+        assert response.result.deleted == 1
+
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 22050),
+    )
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_probed_below_target_source_converts_at_source_rate(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        mock_hi_res,
+        mock_update,
+        _fidelity,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # DB fields say 16/44.1 but the probe reveals a 22.05 kHz source: the
+        # conversion keeps the source rate instead of up-sampling.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        mock_hi_res.assert_called_once_with(
+            "/in.wav", "/out.aif", OutputFormats.AIFF, 22050
+        )
+        assert len(response.result.converted) == 1
+        assert response.result.skipped == []
+
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._convert_to_mp3", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_lossless_mode_keeps_originals_for_mp3_output(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _mp3,
+        _update,
+        mock_remove,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.return_value = ("/out.mp3", "out.mp3", "/")
+        content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db, content)
+
+        response = convert(
+            mock_db,
+            ConvertRequest(
+                format_out="mp3", delete_originals="lossless", overwrite=True
+            ),
+        )
+
+        mock_remove.assert_not_called()
+        assert response.result.deleted == 0
+
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=False)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=False)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -286,8 +532,9 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_rollback,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -303,10 +550,14 @@ class TestConvertRealRun:
 
         mock_rollback.assert_called_once()
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -319,10 +570,11 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_update,
         _remove,
         mock_rollback,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -347,8 +599,12 @@ class TestConvertRealRun:
         mock_db.session.commit.assert_called_once()
         mock_rollback.assert_not_called()
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -361,8 +617,9 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_update,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -392,8 +649,12 @@ class TestConvertRealRun:
         assert [op.id for op in response.result.converted] == ["A", "B", "C"]
         assert [t.ID for t in response.tracks] == ["A", "B", "C"]
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -406,8 +667,9 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         mock_exists,
-        mock_lossless,
+        mock_hi_res,
         mock_update,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -492,12 +754,16 @@ class TestConvertRealRun:
             convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
         mock_rollback.assert_called_once()
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch(
         "rekordbox_edit.api.convert._update_database_record",
         side_effect=RuntimeError("DB error"),
     )
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -510,9 +776,10 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         _exists,
-        _lossless,
+        _hi_res,
         _update,
         mock_rollback,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -558,9 +825,13 @@ class TestConvertRealRun:
 
         mock_mp3.assert_called_once_with("/in.wav", "/out.mp3")
 
+    @patch(
+        "rekordbox_edit.api.convert._classify_source_fidelity",
+        return_value=("lossless", 44100),
+    )
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
-    @patch("rekordbox_edit.api.convert._convert_to_lossless", return_value=True)
+    @patch("rekordbox_edit.api.convert._convert_to_hi_res", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
@@ -573,9 +844,10 @@ class TestConvertRealRun:
         mock_get_output,
         _ffmpeg,
         _exists,
-        _lossless,
+        _hi_res,
         _update,
         mock_remove,
+        _fidelity,
         mock_db,
         make_djmd_content_item,
     ):
@@ -599,15 +871,36 @@ class TestConvertRealRun:
 # ── Helper-function tests (preserved from existing file) ──────────────────
 
 
-class TestConvertToLossless:
+class TestClassifySourceFidelity:
+    @pytest.mark.parametrize(
+        "bit_depth,sample_rate,expected",
+        [
+            (16, 44100, ("lossless", 44100)),
+            (24, 44100, ("lossy", 44100)),
+            (16, 96000, ("lossy", 44100)),
+            (24, 96000, ("lossy", 44100)),
+            (None, 44100, ("lossy", 44100)),  # unknown bit depth: keep originals
+            (8, 44100, ("lossy", 44100)),
+            (16, 22050, ("lossless", 22050)),  # rate clamps to the source
+            (24, 22050, ("lossy", 22050)),
+        ],
+    )
     @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.utils.ffmpeg_in_path")
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_to_aiff_16bit(
-        self, mock_ffmpeg, mock_ffmpeg_in_path, mock_get_audio_info
+    def test_fidelity_classification(
+        self, mock_get_audio_info, bit_depth, sample_rate, expected
     ):
-        mock_ffmpeg_in_path.return_value = True
-        mock_get_audio_info.return_value = {"bit_depth": 16}
+        mock_get_audio_info.return_value = {
+            "bit_depth": bit_depth,
+            "sample_rate": sample_rate,
+        }
+
+        assert _classify_source_fidelity("in.flac") == expected
+
+
+class TestConvertToHiRes:
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_aiff_targets_16bit_44_1khz(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_input = Mock()
         mock_output = Mock()
         mock_ffmpeg.input.return_value = mock_input
@@ -615,116 +908,111 @@ class TestConvertToLossless:
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = _convert_to_lossless("input.flac", "output.aiff", OutputFormats.AIFF)
+        result = _convert_to_hi_res(
+            "input.flac", "output.aiff", OutputFormats.AIFF, 44100
+        )
 
         assert result is True
         mock_input.output.assert_called_once_with(
-            "output.aiff", acodec="pcm_s16be", map_metadata=0, write_id3v2=1
+            "output.aiff", acodec="pcm_s16be", ar=44100, map_metadata=0, write_id3v2=1
         )
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_ffmpeg_not_found_raises(self, _):
         with pytest.raises(Exception, match="FFmpeg not found in PATH"):
-            _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+            _convert_to_hi_res("in.flac", "out.aiff", OutputFormats.AIFF, 44100)
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 24})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_to_wav_24bit(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+    def test_wav_targets_16bit_44_1khz(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_output = Mock()
         mock_ffmpeg.input.return_value.output.return_value = mock_output
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = _convert_to_lossless("in.flac", "out.wav", OutputFormats.WAV)
+        result = _convert_to_hi_res("in.flac", "out.wav", OutputFormats.WAV, 44100)
 
         assert result is True
         mock_ffmpeg.input.return_value.output.assert_called_once_with(
-            "out.wav", acodec="pcm_s24le", map_metadata=0, write_id3v2=1
+            "out.wav", acodec="pcm_s16le", ar=44100, map_metadata=0, write_id3v2=1
         )
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 24})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_convert_to_flac(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+    def test_encodes_at_given_sample_rate(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_output = Mock()
         mock_ffmpeg.input.return_value.output.return_value = mock_output
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.return_value = None
 
-        result = _convert_to_lossless("in.wav", "out.flac", OutputFormats.FLAC)
+        result = _convert_to_hi_res("in.flac", "out.wav", OutputFormats.WAV, 22050)
 
         assert result is True
         mock_ffmpeg.input.return_value.output.assert_called_once_with(
-            "out.flac", acodec="flac", map_metadata=0, write_id3v2=1
+            "out.wav", acodec="pcm_s16le", ar=22050, map_metadata=0, write_id3v2=1
         )
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    def test_unsupported_format_raises(self, _ffmpeg_in_path, _audio):
+    @patch("rekordbox_edit.api.convert.ffmpeg")
+    def test_flac_targets_16bit_via_sample_fmt(self, mock_ffmpeg, _ffmpeg_in_path):
+        mock_output = Mock()
+        mock_ffmpeg.input.return_value.output.return_value = mock_output
+        mock_output.overwrite_output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        result = _convert_to_hi_res("in.wav", "out.flac", OutputFormats.FLAC, 44100)
+
+        assert result is True
+        mock_ffmpeg.input.return_value.output.assert_called_once_with(
+            "out.flac",
+            acodec="flac",
+            ar=44100,
+            map_metadata=0,
+            write_id3v2=1,
+            sample_fmt="s16",
+        )
+
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_unsupported_format_raises(self, _ffmpeg_in_path):
         fake_format = Mock()
         fake_format.value = "xyz"
-        with pytest.raises(Exception, match="Unsupported lossless format"):
-            _convert_to_lossless("in.flac", "out.xyz", fake_format)
+        with pytest.raises(Exception, match="Unsupported hi-res format"):
+            _convert_to_hi_res("in.flac", "out.xyz", fake_format, 44100)
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 8})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unknown_bit_depth_falls_back_to_first_codec(
-        self, mock_ffmpeg, _ffmpeg_in_path, _audio
-    ):
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.return_value = None
-
-        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
-
-        assert result is True
-        # First codec in {16: pcm_s16be, ...} for AIFF.
-        mock_ffmpeg.input.return_value.output.assert_called_once_with(
-            "out.aiff", acodec="pcm_s16be", map_metadata=0, write_id3v2=1
-        )
-
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_output = Mock()
         mock_ffmpeg.input.return_value.output.return_value = mock_output
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", b"stderr")
 
-        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+        result = _convert_to_hi_res("in.flac", "out.aiff", OutputFormats.AIFF, 44100)
 
         assert result is False
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_no_stderr_returns_false(
-        self, mock_ffmpeg, _ffmpeg_in_path, _audio
-    ):
+    def test_ffmpeg_error_no_stderr_returns_false(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_output = Mock()
         mock_ffmpeg.input.return_value.output.return_value = mock_output
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", None)
 
-        result = _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+        result = _convert_to_hi_res("in.flac", "out.aiff", OutputFormats.AIFF, 44100)
 
         assert result is False
 
-    @patch("rekordbox_edit.api.convert.get_audio_info", return_value={"bit_depth": 16})
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unexpected_exception_reraises(self, mock_ffmpeg, _ffmpeg_in_path, _audio):
+    def test_unexpected_exception_reraises(self, mock_ffmpeg, _ffmpeg_in_path):
         mock_output = Mock()
         mock_ffmpeg.input.return_value.output.return_value = mock_output
         mock_output.overwrite_output.return_value = mock_output
         mock_output.run.side_effect = RuntimeError("disk full")
 
         with pytest.raises(RuntimeError, match="disk full"):
-            _convert_to_lossless("in.flac", "out.aiff", OutputFormats.AIFF)
+            _convert_to_hi_res("in.flac", "out.aiff", OutputFormats.AIFF, 44100)
 
 
 class TestConvertToMp3:
@@ -789,13 +1077,53 @@ class TestUpdateDatabaseRecord:
         mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24)
         mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
-        mock_get_audio_info.return_value = {"bitrate": 1000, "bit_depth": 24}
+        mock_get_audio_info.return_value = {
+            "bitrate": 1000,
+            "bit_depth": 24,
+            "sample_rate": 44100,
+        }
 
         _update_database_record(mock_db, 123, "output.flac", "/path/to", "FLAC")
 
         assert mock_content.FileNameL == "output.flac"
         assert mock_content.FolderPath == "/path/to/output.flac"
         assert mock_content.BitRate == 0
+
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_hi_res_output_updates_bit_depth_and_sample_rate(
+        self, mock_get_audio_info, make_djmd_content_item
+    ):
+        mock_db = Mock()
+        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
+        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
+        mock_get_audio_info.return_value = {
+            "bitrate": 1411,
+            "bit_depth": 16,
+            "sample_rate": 44100,
+        }
+
+        _update_database_record(mock_db, 123, "output.aiff", "/path/to", "AIFF")
+
+        assert mock_content.BitDepth == 16
+        assert mock_content.SampleRate == 44100
+
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_unknown_probe_values_leave_db_fields_unchanged(
+        self, mock_get_audio_info, make_djmd_content_item
+    ):
+        mock_db = Mock()
+        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
+        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
+        mock_get_audio_info.return_value = {
+            "bitrate": 1411,
+            "bit_depth": None,
+            "sample_rate": None,
+        }
+
+        _update_database_record(mock_db, 123, "output.aiff", "/path/to", "AIFF")
+
+        assert mock_content.BitDepth == 24
+        assert mock_content.SampleRate == 96000
 
     @patch("rekordbox_edit.api.convert.get_audio_info")
     def test_mp3_sets_bitrate_from_probe(

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -158,7 +158,9 @@ class TestEditRealRun:
         ]
         mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        response = edit(mock_db, EditRequest(field="Title", replace_value="x", multi=True))
+        response = edit(
+            mock_db, EditRequest(field="Title", replace_value="x", multi=True)
+        )
 
         # The order of result.edits follows the classifier (i.e. the order
         # of contents). tracks aligns to edits.

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -93,7 +93,7 @@ class TestNarrowToTrackIds:
             format=["flac"],
             format_out="aiff",
             overwrite=True,
-            delete=True,
+            delete_originals="all",
         )
 
         narrowed = _narrow_to_track_ids(args, ["a", "b"])
@@ -104,7 +104,7 @@ class TestNarrowToTrackIds:
         # Convert-specific fields preserved
         assert narrowed.format_out == "aiff"
         assert narrowed.overwrite is True
-        assert narrowed.delete is True
+        assert narrowed.delete_originals == "all"
 
     def test_works_for_edit_args(self):
         args = EditRequest(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def make_djmd_content_item():
             "FolderPath",
             "/super/very/extra/unnecessarily/long/path/to/music/test_track.wav",
         )
-        item.SampleRate = kwargs.get("SampleRate", 41000)
+        item.SampleRate = kwargs.get("SampleRate", 44100)
         item.BitDepth = kwargs.get("BitDepth", 16)
         item.BitRate = kwargs.get("BitRate", 2113)
         item.FileType = kwargs.get("FileType", 11)
@@ -66,7 +66,7 @@ def make_track():
                 "FolderPath",
                 "/super/very/extra/unnecessarily/long/path/to/music/test_track.wav",
             ),
-            SampleRate=kwargs.get("SampleRate", 41000),
+            SampleRate=kwargs.get("SampleRate", 44100),
             BitDepth=kwargs.get("BitDepth", 16),
             BitRate=kwargs.get("BitRate", 2113),
             FileType=kwargs.get("FileType", 11),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,7 +97,7 @@ class TestConvertRequest:
         assert isinstance(args, FilterArgs)
         assert args.format_out == "mp3"
         assert args.overwrite is True
-        assert args.delete is None
+        assert args.delete_originals == "lossless"
         assert args.artist == ["X"]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,8 +74,6 @@ class TestGetGetExtensionForFormat:
         assert get_extension_for_format("wav") == ".wav"
         assert get_extension_for_format("AIFF") == ".aiff"
         assert get_extension_for_format("aiff") == ".aiff"
-        assert get_extension_for_format("ALAC") == ".m4a"
-        assert get_extension_for_format("alac") == ".m4a"
 
     def test_get_extension_for_format_invalid(self):
         """Test get_extension_for_format with invalid formats."""


### PR DESCRIPTION
[BREAKING(convert): replace --delete/--keep with --delete-originals enum](https://github.com/jviall/rekordbox-edit/pull/94/changes/c412400a43e9b88b3eb56b62c70c465dba6e90c6)

The tri-state boolean becomes an explicit mode: 'none' never deletes,
'all' always deletes, 'lossless' (default) deletes only for hi-res
output formats. Also drops the unsupported 'alac' --format-out choice,
which crashed at conversion time.

[fix(convert): respect bit depth and sample rate between hi-res formats](https://github.com/jviall/rekordbox-edit/pull/94/changes/68ef18e873b7deff9d7165c5bcd917a1d740d769)

Fixes #92 

[feat(convert): report audio properties on ConvertOp](https://github.com/jviall/rekordbox-edit/pull/94/changes/0037ddff794113f3fdc0b634403683c203fff551)
[fix(convert): update MP3 bit depth and sample rate in database](https://github.com/jviall/rekordbox-edit/pull/94/changes/44778d0048242dac7aa4b974025b7fbd36a57868)
[fix(convert): encode MP3 at the target bit depth and sample rate](https://github.com/jviall/rekordbox-edit/pull/94/changes/064711c3d16b25ce1b4b9f80f7c674673f8ab453)
It's possible for MP3s to at a different sample rate, but mpeg-1's have to be 16-bit and the potential of a sub-44.1k sample rate is not something I'm going to worry about--always encode mp3s to 16bit 44.1k.