### PR TITLE
feat: support all rekordbox FileType values

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -17,7 +17,7 @@ Repeating a filter, or combining different filters, matches tracks that satisfy 
 | `--exact-album TEXT` | album name is exactly `TEXT` |
 | `--playlist TEXT` | playlist name contains `TEXT` |
 | `--exact-playlist TEXT` | playlist name is exactly `TEXT` |
-| `--format FMT` | file format is `FMT` (`mp3`, `flac`, `aiff`, `wav`, `m4a`) |
+| `--format FMT` | Rekordbox file type is `FMT` (`mp3`, `mp4`, `aac`, `flac`, `alac`, `wav`, `aiff`, `video`, `invalid`) |
 | `--path TEXT` | file path contains `TEXT` (matched against the folder path, filename, or both) |
 | `--exact-path TEXT` | file path is exactly `TEXT` (resolved to an absolute path before matching) |
 | `--first N` | return only the first N results |

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -91,7 +91,10 @@ global_click_filters = [
     ),
     click.option(
         "--format",
-        type=click.Choice(["mp3", "flac", "aiff", "wav", "m4a"], case_sensitive=False),
+        type=click.Choice(
+            ["mp3", "mp4", "aac", "flac", "alac", "wav", "aiff", "video", "invalid"],
+            case_sensitive=False,
+        ),
         multiple=True,
         help="Find tracks of this format",
     ),

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -21,7 +21,7 @@ from rekordbox_edit.models import (
 )
 from rekordbox_edit.query import get_filtered_content
 from rekordbox_edit.utils import (
-    InputFormats,
+    FILE_TYPES,
     OutputFormats,
     get_audio_info,
     get_extension_for_format,
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 TARGET_BIT_DEPTH = 16
 TARGET_SAMPLE_RATE = 44100
 
-# Rekordbox FileType codes RBE converts from: the hi-res lossless whitelist.
-_INPUT_FILE_TYPES = {get_file_type_for_format(fmt.value) for fmt in InputFormats}
+# Rekordbox FileType codes RBE converts from: the lossless whitelist.
+_INPUT_FILE_TYPES = {code for code, info in FILE_TYPES.items() if info.convertable}
 
 _HI_RES_CODECS = {
     "aiff": "pcm_s16be",

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -22,11 +22,13 @@ from rekordbox_edit.models import (
 from rekordbox_edit.query import get_filtered_content
 from rekordbox_edit.utils import (
     FILE_TYPES,
+    AudioInfo,
     OutputFormats,
     get_audio_info,
     get_extension_for_format,
     get_file_type_for_format,
     get_file_type_name,
+    probe_matches_file_type,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,16 +57,14 @@ def _effective_sample_rate(source_rate: int | None) -> int:
     return TARGET_SAMPLE_RATE
 
 
-def _classify_source_fidelity(
-    source_path,
+def _classify_fidelity(
+    audio_info: AudioInfo,
 ) -> Tuple[Literal["lossless", "lossy"], int]:
-    """Probe a source file and return the conversion's fidelity along with
-    its effective sample rate. "lossless" means no audio information is lost:
-    the source is at the target bit depth and at or below the target sample
-    rate. An unknown bit depth counts as lossy so originals are kept when in
-    doubt.
+    """The conversion's fidelity and effective sample rate for a probed
+    source. "lossless" means no audio information is lost: the source is at
+    the target bit depth and at or below the target sample rate. An unknown
+    bit depth counts as lossy so originals are kept when in doubt.
     """
-    audio_info = get_audio_info(source_path)
     bit_depth = audio_info["bit_depth"]
     sample_rate = audio_info["sample_rate"]
     logger.debug(
@@ -374,13 +374,25 @@ def convert(
             if not os.path.exists(src):
                 raise RuntimeError(f"Source not found: {src}")
 
+            audio_info = get_audio_info(src)
+            if not probe_matches_file_type(
+                content.FileType, audio_info["codec"], audio_info["container"]
+            ):
+                logger.warning(
+                    f"Skipping {content.FileNameL}: probed codec "
+                    f"{audio_info['codec']!r} does not match its Rekordbox "
+                    f"file type {get_file_type_name(content.FileType)!r}"
+                )
+                skipped.append(SkippedTrack(id=op.id, reason="codec_mismatch"))
+                continue
+
             if args.format_out.upper() == "MP3":
                 output_sample_rate = TARGET_SAMPLE_RATE
                 success = _run_ffmpeg(
                     src, op.output_path, _mp3_output_kwargs(output_sample_rate), "mp3"
                 )
             else:
-                fidelity, output_sample_rate = _classify_source_fidelity(src)
+                fidelity, output_sample_rate = _classify_fidelity(audio_info)
                 if fidelity == "lossless":
                     lossless_op_ids.add(op.id)
                 output_format = OutputFormats(args.format_out.lower())

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -48,9 +48,10 @@ logger = logging.getLogger(__name__)
 def convert_command(db, **kwargs):
     """Convert hi-res audio files between formats and update RekordBox database.
 
-    Supports conversion from any hi-res format (FLAC, AIFF, WAV) to:
-    AIFF, FLAC, WAV, or MP3. Skips lossy formats and files already in
-    the target format.
+    Supports conversion from any hi-res format (FLAC, ALAC, AIFF, WAV) to:
+    AIFF, FLAC, WAV, or MP3. Skips lossy formats, video, and files already
+    in the target format. Each source's codec is verified against its
+    database file type before converting; mismatches are skipped.
 
     Lossless conversions target 16-bit/44.1 kHz: higher-resolution sources
     are down-sampled, and sources below the target keep their own sample
@@ -122,6 +123,9 @@ def convert_command(db, **kwargs):
             return
         response = convert(db, args)
 
+    # The preview cannot surface codec_mismatch (dry runs never probe), so
+    # report skips found only during the live run.
+    _report_skips([s for s in response.result.skipped if s.reason == "codec_mismatch"])
     _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
 
 
@@ -129,16 +133,22 @@ def _report_skips(skipped) -> None:
     already_target = sum(1 for s in skipped if s.reason == "already_target_format")
     unsupported = sum(1 for s in skipped if s.reason == "unsupported_source_format")
     conflicts = sum(1 for s in skipped if s.reason == "output_file_exists")
+    mismatches = sum(1 for s in skipped if s.reason == "codec_mismatch")
     if already_target:
         logger.warning(f"Skipping {already_target} file(s): already in target format")
     if unsupported:
         logger.warning(
             f"Skipping {unsupported} file(s): unsupported source format "
-            "(only FLAC, AIFF, WAV are converted)"
+            "(only FLAC, ALAC, AIFF, WAV are converted)"
         )
     if conflicts:
         logger.warning(
             f"Skipping {conflicts} file(s): output exists (use --overwrite to convert)"
+        )
+    if mismatches:
+        logger.warning(
+            f"Skipping {mismatches} file(s): file content does not match its "
+            "Rekordbox file type"
         )
 
 

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -130,6 +130,7 @@ SkipReason: TypeAlias = Literal[
     "already_target_format",
     "unsupported_source_format",
     "output_file_exists",
+    "codec_mismatch",
 ]
 
 

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -132,7 +132,7 @@ class CollectionQuery:
 
     def by_format(self, format_name: str) -> "CollectionQuery":
         """Filter by file format."""
-        from rekordbox_edit.utils import get_file_type_for_format
+        from rekordbox_edit.utils import get_file_type_codes_for_format
 
         if not format_name:
             logger.warning("Empty format filter has no effect")
@@ -141,8 +141,8 @@ class CollectionQuery:
         new_inst = self._copy()
 
         try:
-            file_type_code = get_file_type_for_format(format_name)
-            condition = DjmdContent.FileType == file_type_code
+            file_type_codes = get_file_type_codes_for_format(format_name)
+            condition = DjmdContent.FileType.in_(file_type_codes)
             new_inst._conditions.append(condition)
         except ValueError:
             logger.warning(f"Invalid format: {format_name}")

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -3,6 +3,7 @@
 import logging
 import platform
 import shutil
+from dataclasses import dataclass
 from enum import Enum
 
 import click
@@ -17,61 +18,112 @@ class UserQuit(Exception):
     pass
 
 
-# File type mappings for Rekordbox database
-def get_file_type_name(file_type_code: int | None) -> str | None:
-    """Map a Rekordbox FileType code to a display name, or None if unmapped.
+@dataclass(frozen=True)
+class FileTypeInfo:
+    """One Rekordbox FileType code: how RBE names, filters, probes, and
+    converts it. ``codecs`` are ffprobe codec_name prefixes and
+    ``containers`` are format_name substrings; a probe must satisfy both
+    (WAV and AIFF share PCM codecs, so their containers disambiguate)."""
 
-    A total display map, not a guard: Rekordbox stores many codes RBE does not
-    convert (AAC, ALAC, video). Each caller chooses its own fallback for None.
-    """
+    code: int
+    name: str
+    token: str
+    extension: str | None = None
+    codecs: tuple[str, ...] = ()
+    containers: tuple[str, ...] = ()
+    convertable: bool = False
+
+
+FILE_TYPES: dict[int, FileTypeInfo] = {
+    # Corrupt or empty content, independent of container.
+    0: FileTypeInfo(code=0, name="INVALID", token="invalid"),
+    1: FileTypeInfo(code=1, name="MP3", token="mp3", extension=".mp3", codecs=("mp3",)),
+    # 3 is the .mp4 container regardless of content: audio-only AAC/ALAC
+    # .mp4 files land here alongside video .mp4, so RBE never converts it.
+    3: FileTypeInfo(code=3, name="MP4", token="mp4"),
+    4: FileTypeInfo(code=4, name="AAC", token="aac", codecs=("aac",)),
+    5: FileTypeInfo(
+        code=5,
+        name="FLAC",
+        token="flac",
+        extension=".flac",
+        codecs=("flac",),
+        convertable=True,
+    ),
+    6: FileTypeInfo(
+        code=6,
+        name="ALAC",
+        token="alac",
+        codecs=("alac",),
+        convertable=True,
+    ),
+    11: FileTypeInfo(
+        code=11,
+        name="WAV",
+        token="wav",
+        extension=".wav",
+        codecs=("pcm_",),
+        containers=("wav",),
+        convertable=True,
+    ),
+    12: FileTypeInfo(
+        code=12,
+        name="AIFF",
+        token="aiff",
+        extension=".aiff",
+        codecs=("pcm_",),
+        containers=("aiff",),
+        convertable=True,
+    ),
+    # Catch-all for non-mp4 video containers (avi, m4v, mov, mpg).
+    16: FileTypeInfo(code=16, name="VIDEO", token="video"),
+}
+
+
+def get_file_type_name(file_type_code: int | None) -> str | None:
+    """Map a Rekordbox FileType code to a display name, or None if unmapped."""
     if file_type_code is None:
         return None
-    _get_file_type_name = {
-        0: "MP3",
-        1: "MP3",
-        4: "M4A",
-        5: "FLAC",
-        11: "WAV",
-        12: "AIFF",
-    }
-    return _get_file_type_name.get(file_type_code)
+    info = FILE_TYPES.get(file_type_code)
+    return info.name if info else None
 
 
-def get_file_type_for_format(format_name: str):
-    """Get file type code for format name (case-insensitive)."""
+def get_file_type_codes_for_format(format_name: str) -> set[int]:
+    """All FileType codes a format token matches (case-insensitive).
+
+    Tokens mirror FileType values one to one.
+    """
     if not format_name:
         raise ValueError("Format name cannot be empty or None")
-    _get_file_type_for_format = {"MP3": 1, "M4A": 4, "FLAC": 5, "WAV": 11, "AIFF": 12}
-    file_type = _get_file_type_for_format.get(format_name.upper())
-    if file_type is None:
+    token = format_name.lower()
+    codes = {code for code, info in FILE_TYPES.items() if token == info.token}
+    if not codes:
         raise ValueError(f"Unknown format: {format_name}")
-    return file_type
+    return codes
 
 
-def get_extension_for_format(format_name: str):
-    """Get file extension for format name (case-insensitive)."""
+def get_file_type_for_format(format_name: str) -> int:
+    """The FileType code Rekordbox records for files RBE writes in this
+    output format (case-insensitive). Raises for non-output formats."""
     if not format_name:
         raise ValueError("Format name cannot be empty or None")
-    _get_extension_for_format = {
-        "MP3": ".mp3",
-        "AIFF": ".aiff",
-        "FLAC": ".flac",
-        "WAV": ".wav",
-    }
-    extension = _get_extension_for_format.get(format_name.upper())
-    if extension is None:
-        raise ValueError(f"Unknown format: {format_name}")
+    token = format_name.lower()
+    for code, info in FILE_TYPES.items():
+        if info.extension and token == info.token:
+            return code
+    raise ValueError(f"Unknown format: {format_name}")
+
+
+def get_extension_for_format(format_name: str) -> str:
+    """Get file extension for an output format name (case-insensitive)."""
+    code = get_file_type_for_format(format_name)
+    extension = FILE_TYPES[code].extension
+    assert extension is not None  # get_file_type_for_format only returns such codes
     return extension
 
 
 class OutputFormats(Enum):
     MP3 = "mp3"
-    FLAC = "flac"
-    AIFF = "aiff"
-    WAV = "wav"
-
-
-class InputFormats(Enum):
     FLAC = "flac"
     AIFF = "aiff"
     WAV = "wav"

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -123,6 +123,25 @@ def get_extension_for_format(format_name: str) -> str:
     return extension
 
 
+def probe_matches_file_type(
+    file_type_code: int | None, codec: str | None, container: str | None
+) -> bool:
+    """Whether a probed codec/container is consistent with a Rekordbox
+    FileType code. Unknown codes never match, so callers treat them as
+    mismatches instead of converting blind."""
+    if file_type_code is None:
+        return False
+    info = FILE_TYPES.get(file_type_code)
+    if info is None:
+        return False
+    if info.codecs and not (codec or "").startswith(info.codecs):
+        return False
+    if info.containers:
+        if not container or not any(c in container for c in info.containers):
+            return False
+    return True
+
+
 class OutputFormats(Enum):
     MP3 = "mp3"
     FLAC = "flac"

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 from dataclasses import dataclass
 from enum import Enum
+from typing import TypedDict
 
 import click
 import ffmpeg
@@ -151,12 +152,24 @@ or https://ffmpeg.org/download.html
 """
 
 
-def get_audio_info(file_path) -> dict[str, int | None]:
+class AudioInfo(TypedDict):
+    """Fields extracted from an ffmpeg probe of one audio file."""
+
+    bit_depth: int | None
+    sample_rate: int
+    channels: int
+    bitrate: int | None
+    codec: str | None
+    container: str | None
+
+
+def get_audio_info(file_path) -> AudioInfo:
     """Get audio information from file using ffmpeg probe.
 
     Returns None for any field that cannot be determined from the probe data.
-    Callers are responsible for handling None values and applying format-specific
-    assumptions (e.g. MP3 has no true bit depth).
+    Callers are responsible for handling None values and applying
+    format-specific assumptions (e.g. MP3 has no true bit depth). ``codec``
+    is the stream's codec_name and ``container`` the probe's format_name.
     """
     try:
         # Check if ffmpeg is available first
@@ -215,6 +228,8 @@ def get_audio_info(file_path) -> dict[str, int | None]:
             "sample_rate": int(audio_stream.get("sample_rate", 44100)),
             "channels": int(audio_stream.get("channels", 2)),
             "bitrate": bitrate,
+            "codec": audio_stream.get("codec_name"),
+            "container": probe.get("format", {}).get("format_name"),
         }
     except Exception as e:
         logger.error(f"Failed to get audio info for {file_path}: {e}")

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -6,7 +6,7 @@ import pytest
 
 from rekordbox_edit.api.convert import (
     _classify_convert,
-    _classify_source_fidelity,
+    _classify_fidelity,
     _cleanup_converted_files,
     _get_output_path,
     _hi_res_output_kwargs,
@@ -23,7 +23,40 @@ from rekordbox_edit.models import (
     ConvertResponse,
     SkippedTrack,
 )
-from rekordbox_edit.utils import OutputFormats
+from rekordbox_edit.utils import AudioInfo, OutputFormats
+
+_PROBE_WAV_16_44 = {
+    "bit_depth": 16,
+    "sample_rate": 44100,
+    "channels": 2,
+    "bitrate": 1411,
+    "codec": "pcm_s16le",
+    "container": "wav",
+}
+_PROBE_WAV_24_96 = {
+    "bit_depth": 24,
+    "sample_rate": 96000,
+    "channels": 2,
+    "bitrate": 4608,
+    "codec": "pcm_s24le",
+    "container": "wav",
+}
+_PROBE_WAV_16_22 = {
+    "bit_depth": 16,
+    "sample_rate": 22050,
+    "channels": 2,
+    "bitrate": 705,
+    "codec": "pcm_s16le",
+    "container": "wav",
+}
+_PROBE_AAC_M4A = {
+    "bit_depth": 16,
+    "sample_rate": 44100,
+    "channels": 2,
+    "bitrate": 256,
+    "codec": "aac",
+    "container": "mov,mp4,m4a,3gp,3g2,mj2",
+}
 
 
 class TestClassifyConvert:
@@ -333,10 +366,90 @@ class TestConvertRealRun:
         assert response.tracks == []
         mock_db.session.commit.assert_not_called()
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_codec_mismatch_skips_track_and_continues(
+        self,
+        mock_gfc,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        mock_update,
+        mock_probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # Row A claims ALAC but holds AAC; row B is a genuine WAV. A is
+        # skipped with codec_mismatch, B converts, and the run commits.
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        mismatched = make_djmd_content_item(ID="A", FileType=6, FolderPath="/A.m4a")
+        good = make_djmd_content_item(ID="B", FileType=11, FolderPath="/B.wav")
+        _seed_filter(mock_gfc, mismatched, good)
+        _seed_db(mock_db, good)
+        mock_probe.side_effect = lambda path: (
+            _PROBE_AAC_M4A if path == "/A.m4a" else _PROBE_WAV_16_44
+        )
+
+        response = convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="none", overwrite=True),
+        )
+
+        assert [op.id for op in response.result.converted] == ["B"]
+        assert [t.ID for t in response.tracks] == ["B"]
+        assert {(s.id, s.reason) for s in response.result.skipped} == {
+            ("A", "codec_mismatch")
+        }
+        mock_run.assert_called_once()
+        mock_update.assert_called_once()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_AAC_M4A)
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_codec_mismatch_never_touches_files(
+        self,
+        mock_gfc,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        mock_remove,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # Every op mismatches: no ffmpeg run, no deletion, empty response.
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="A", FileType=6, FolderPath="/A.m4a")
+        _seed_filter(mock_gfc, content)
+        _seed_db(mock_db)
+
+        response = convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", delete_originals="all", overwrite=True),
+        )
+
+        mock_run.assert_not_called()
+        mock_remove.assert_not_called()
+        assert response.result.converted == []
+        assert response.result.skipped[0].reason == "codec_mismatch"
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -353,7 +466,7 @@ class TestConvertRealRun:
         mock_exists,
         mock_run,
         mock_update,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -389,10 +502,7 @@ class TestConvertRealRun:
         assert response.result.deleted == 0
         assert response.tracks[0].ID == "1"
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -411,7 +521,7 @@ class TestConvertRealRun:
         mock_hi_res,
         mock_update,
         mock_remove,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -431,10 +541,7 @@ class TestConvertRealRun:
         mock_remove.assert_called_once_with("/in.wav")
         assert response.result.deleted == 1
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossy", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_24_96)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -453,7 +560,7 @@ class TestConvertRealRun:
         mock_hi_res,
         mock_update,
         mock_remove,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -477,10 +584,7 @@ class TestConvertRealRun:
         assert response.result.deleted == 0
         assert len(response.result.converted) == 1
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossy", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_24_96)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -499,7 +603,7 @@ class TestConvertRealRun:
         mock_hi_res,
         mock_update,
         mock_remove,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -519,10 +623,7 @@ class TestConvertRealRun:
         mock_remove.assert_called_once_with("/in.wav")
         assert response.result.deleted == 1
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -541,7 +642,7 @@ class TestConvertRealRun:
         mock_hi_res,
         mock_update,
         mock_remove,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -563,10 +664,7 @@ class TestConvertRealRun:
         mock_remove.assert_called_once_with("/in.wav")
         assert response.result.deleted == 1
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 22050),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_22)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -583,7 +681,7 @@ class TestConvertRealRun:
         mock_exists,
         mock_run,
         mock_update,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -610,6 +708,7 @@ class TestConvertRealRun:
         assert op.output_sample_rate == 22050
         assert response.result.skipped == []
 
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -628,6 +727,7 @@ class TestConvertRealRun:
         _mp3,
         _update,
         mock_remove,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -649,10 +749,7 @@ class TestConvertRealRun:
         mock_remove.assert_not_called()
         assert response.result.deleted == 0
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=False)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -669,7 +766,7 @@ class TestConvertRealRun:
         mock_exists,
         mock_hi_res,
         mock_rollback,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -685,10 +782,7 @@ class TestConvertRealRun:
 
         mock_rollback.assert_called_once()
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
     @patch("rekordbox_edit.api.convert._update_database_record")
@@ -709,7 +803,7 @@ class TestConvertRealRun:
         mock_update,
         _remove,
         mock_rollback,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -734,10 +828,7 @@ class TestConvertRealRun:
         mock_db.session.commit.assert_called_once()
         mock_rollback.assert_not_called()
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -754,7 +845,7 @@ class TestConvertRealRun:
         mock_exists,
         mock_hi_res,
         mock_update,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -784,10 +875,7 @@ class TestConvertRealRun:
         assert [op.id for op in response.result.converted] == ["A", "B", "C"]
         assert [t.ID for t in response.tracks] == ["A", "B", "C"]
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -804,7 +892,7 @@ class TestConvertRealRun:
         mock_exists,
         mock_hi_res,
         mock_update,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -889,10 +977,7 @@ class TestConvertRealRun:
             convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
         mock_rollback.assert_called_once()
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
     @patch(
         "rekordbox_edit.api.convert._update_database_record",
@@ -914,7 +999,7 @@ class TestConvertRealRun:
         _hi_res,
         _update,
         mock_rollback,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -929,6 +1014,7 @@ class TestConvertRealRun:
             convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
         mock_rollback.assert_called_once()
 
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -945,6 +1031,7 @@ class TestConvertRealRun:
         _exists,
         mock_run,
         _update,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -962,10 +1049,7 @@ class TestConvertRealRun:
             "/in.wav", "/out.mp3", _mp3_output_kwargs(44100), "mp3"
         )
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -984,7 +1068,7 @@ class TestConvertRealRun:
         _hi_res,
         _update,
         mock_remove,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -1004,10 +1088,7 @@ class TestConvertRealRun:
         mock_remove.assert_not_called()
         assert response.result.deleted == 0
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_anlz_paths")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -1026,7 +1107,7 @@ class TestConvertRealRun:
         _run,
         _update,
         mock_anlz,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -1048,10 +1129,7 @@ class TestConvertRealRun:
         mock_db.session.commit.assert_called_once()
         mock_anlz.assert_called_once_with(mock_db, content, "out.aif")
 
-    @patch(
-        "rekordbox_edit.api.convert._classify_source_fidelity",
-        return_value=("lossless", 44100),
-    )
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch(
         "rekordbox_edit.api.convert._update_anlz_paths",
         side_effect=RuntimeError("ANLZ write failed"),
@@ -1075,7 +1153,7 @@ class TestConvertRealRun:
         _update,
         mock_rollback,
         _anlz,
-        _fidelity,
+        _probe,
         mock_db,
         make_djmd_content_item,
     ):
@@ -1103,7 +1181,7 @@ class TestConvertRealRun:
 # ── Helper-function tests (preserved from existing file) ──────────────────
 
 
-class TestClassifySourceFidelity:
+class TestClassifyFidelity:
     @pytest.mark.parametrize(
         "bit_depth,sample_rate,expected",
         [
@@ -1117,16 +1195,17 @@ class TestClassifySourceFidelity:
             (24, 22050, ("lossy", 22050)),
         ],
     )
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_fidelity_classification(
-        self, mock_get_audio_info, bit_depth, sample_rate, expected
-    ):
-        mock_get_audio_info.return_value = {
+    def test_fidelity_classification(self, bit_depth, sample_rate, expected):
+        audio_info: AudioInfo = {
             "bit_depth": bit_depth,
             "sample_rate": sample_rate,
+            "channels": 2,
+            "bitrate": None,
+            "codec": "flac",
+            "container": "flac",
         }
 
-        assert _classify_source_fidelity("in.flac") == expected
+        assert _classify_fidelity(audio_info) == expected
 
 
 class TestRunFfmpeg:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -224,6 +224,27 @@ class TestClassifyConvert:
         assert result.output_bit_depth == 16
         assert result.output_sample_rate == 44100
 
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    def test_alac_source_is_convertible(
+        self, mock_get_output, mock_exists, make_djmd_content_item
+    ):
+        mock_get_output.return_value = ("/out.aif", "out.aif", "/")
+        content = make_djmd_content_item(ID="10", FileType=6, FolderPath="/in.m4a")
+
+        result = _classify_convert(content, ConvertRequest(format_out="aiff"))
+
+        assert isinstance(result, ConvertOp)
+        assert result.source_file_type == "ALAC"
+
+    def test_aac_source_skipped_as_unsupported(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID="11", FileType=4)
+
+        result = _classify_convert(content, ConvertRequest(format_out="aiff"))
+
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "unsupported_source_format"
+
 
 def _seed_db(mock_db, *contents):
     """Make mock_db.session.execute(select).scalars().all() return contents."""

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -183,6 +183,32 @@ class TestConvertCommand:
         assert mock_convert.call_args_list[1].kwargs.get("dry_run", False) is False
 
     @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_default_flow_reports_live_codec_mismatch_once(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        # The preview cannot detect codec_mismatch (dry runs never probe);
+        # only the live run surfaces it. Both runs report the same
+        # classification skip, which must not be warned about twice.
+        preview_skips = [SkippedTrack(id="2", reason="already_target_format")]
+        live_skips = preview_skips + [SkippedTrack(id="3", reason="codec_mismatch")]
+        mock_convert.side_effect = [
+            _response(skipped=preview_skips),
+            _response(skipped=live_skips),
+        ]
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert sum("does not match" in w for w in warnings) == 1
+        assert sum("already" in w for w in warnings) == 1
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
     @patch("rekordbox_edit.cli.convert.confirm", return_value=False)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -16,6 +16,12 @@ def mock_logger():
         yield mock_log
 
 
+@pytest.fixture(autouse=True)
+def mock_rekordbox_not_running():
+    with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+        yield
+
+
 def _response(tracks=None, edits=None, skipped=None):
     tracks = tracks or [
         Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -149,7 +149,7 @@ class TestPrintTrackInfo:
         """Test printing track with unknown file type."""
         mock_content = make_track(
             ID="123",
-            FileType=6,
+            FileType=99,
         )
 
         print_track_info([mock_content], self.TEST_PRINT_COLUMNS)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -256,12 +256,11 @@ class TestCollectionQuery:
 
     def test_by_format(self, mocker):
         """Test that the by_format method does not modify the statement and
-        adds a condition on the DjmdContent.FileType field."""
-        # Mock the get_file_type_for_format function
-        mock_get_file_type = mocker.patch(
-            "rekordbox_edit.utils.get_file_type_for_format"
+        adds an IN condition on the DjmdContent.FileType field."""
+        mock_get_codes = mocker.patch(
+            "rekordbox_edit.utils.get_file_type_codes_for_format"
         )
-        mock_get_file_type.return_value = 5  # Example file type code
+        mock_get_codes.return_value = {5}
 
         query = CollectionQuery()
         format_name = "FLAC"
@@ -279,12 +278,13 @@ class TestCollectionQuery:
         new_stmt_str = str(new_query._stmt)
         assert new_stmt_str == original_stmt_str
 
-        # Check that the condition involves FileType
+        # Check that the condition is an IN over FileType
         condition_str = str(new_query._conditions[0]).lower()
         assert "filetype" in condition_str
+        assert "in" in condition_str
 
         # Verify the helper function was called
-        mock_get_file_type.assert_called_once_with(format_name)
+        mock_get_codes.assert_called_once_with(format_name)
 
     def test_copy(self):
         """ """
@@ -378,7 +378,7 @@ class TestCollectionQuery:
     def test_by_format_invalid(self, mocker):
         """Invalid format logs a warning and returns a copy without adding a condition."""
         mocker.patch(
-            "rekordbox_edit.utils.get_file_type_for_format",
+            "rekordbox_edit.utils.get_file_type_codes_for_format",
             side_effect=ValueError("unknown format"),
         )
         mock_warn = mocker.patch("rekordbox_edit.query.logger")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from rekordbox_edit.utils import (
     get_file_type_codes_for_format,
     get_file_type_for_format,
     get_file_type_name,
+    probe_matches_file_type,
 )
 
 
@@ -462,3 +463,28 @@ class TestConfirm:
 
         with pytest.raises(UserQuit, match="User quit"):
             confirm("Continue?", default=True, abort=False)
+
+
+class TestProbeMatchesFileType:
+    @pytest.mark.parametrize(
+        "code,codec,container,expected",
+        [
+            (5, "flac", "flac", True),
+            (6, "alac", "mov,mp4,m4a,3gp,3g2,mj2", True),
+            (6, "aac", "mov,mp4,m4a,3gp,3g2,mj2", False),  # lossy posing as ALAC
+            (4, "aac", "mov,mp4,m4a,3gp,3g2,mj2", True),
+            (11, "pcm_s16le", "wav", True),
+            (11, "pcm_s24le", "wav", True),
+            (11, "flac", "wav", False),
+            (11, "pcm_s16le", "aiff", False),  # container disambiguates PCM
+            (12, "pcm_s16be", "aiff", True),
+            (12, "pcm_s16le", "wav", False),
+            (1, "mp3", "mp3", True),
+            (1, "flac", "flac", False),
+            (99, "flac", "flac", False),  # unknown codes never match
+            (None, "flac", "flac", False),
+            (5, None, None, False),
+        ],
+    )
+    def test_matching(self, code, codec, container, expected):
+        assert probe_matches_file_type(code, codec, container) is expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,25 +8,36 @@ from rekordbox_edit.utils import (
     UserQuit,
     get_audio_info,
     get_extension_for_format,
+    get_file_type_codes_for_format,
     get_file_type_for_format,
     get_file_type_name,
 )
 
 
 class TestGetFileTypeName:
-    """Test getter functions."""
+    """Test file type name mapping."""
 
     def test_get_file_type_name_known_types(self):
         """Test get_file_type_name with known file type codes."""
-        assert get_file_type_name(0) == "MP3"
         assert get_file_type_name(1) == "MP3"
-        assert get_file_type_name(4) == "M4A"
+        assert get_file_type_name(4) == "AAC"
         assert get_file_type_name(5) == "FLAC"
+        assert get_file_type_name(6) == "ALAC"
         assert get_file_type_name(11) == "WAV"
         assert get_file_type_name(12) == "AIFF"
 
+    def test_get_file_type_name_video_types(self):
+        """Code 3 is the .mp4 container regardless of content; code 16
+        covers every other video container (avi, m4v, mov, mpg)."""
+        assert get_file_type_name(3) == "MP4"
+        assert get_file_type_name(16) == "VIDEO"
+
+    def test_get_file_type_name_invalid_type(self):
+        """Code 0 means corrupt or empty content, independent of container."""
+        assert get_file_type_name(0) == "INVALID"
+
     def test_get_file_type_name_unknown_types(self):
-        """Unmapped codes return None instead of raising; the map is total."""
+        """Unknown codes return None so callers pick their own fallback."""
         assert get_file_type_name(None) is None
         assert get_file_type_name(-1) is None
         assert get_file_type_name(99) is None
@@ -34,7 +45,7 @@ class TestGetFileTypeName:
 
 class TestGetFileTypeForFormat:
     def test_get_file_type_for_format_case_insensitive(self):
-        """Test get_file_type_for_format is case-insensitive."""
+        """Output formats resolve to their unique code, case-insensitively."""
         assert get_file_type_for_format("MP3") == 1
         assert get_file_type_for_format("mp3") == 1
         assert get_file_type_for_format("Mp3") == 1
@@ -42,46 +53,71 @@ class TestGetFileTypeForFormat:
         assert get_file_type_for_format("flac") == 5
         assert get_file_type_for_format("wav") == 11
         assert get_file_type_for_format("AIFF") == 12
-        assert get_file_type_for_format("M4A") == 4
+
+    def test_get_file_type_for_format_rejects_non_output_formats(self):
+        """Tokens RBE cannot write as output are rejected."""
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("aac")
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("alac")
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("mp4")
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("video")
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("invalid")
 
     def test_get_file_type_for_format_invalid(self):
         """Test get_file_type_for_format with invalid formats."""
-        import pytest
-
-        with pytest.raises(ValueError, match="Unknown format: invalid"):
-            get_file_type_for_format("invalid")
-
-        with pytest.raises(ValueError, match="Format name cannot be empty or None"):
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_for_format("xyz")
+        with pytest.raises(ValueError, match="cannot be empty"):
             get_file_type_for_format("")
-
-        with pytest.raises(ValueError, match="Format name cannot be empty or None"):
+        with pytest.raises(ValueError, match="cannot be empty"):
             get_file_type_for_format(None)  # ty: ignore[invalid-argument-type]
 
 
-class TestGetGetExtensionForFormat:
+class TestGetFileTypeCodesForFormat:
+    def test_single_code_tokens(self):
+        assert get_file_type_codes_for_format("mp3") == {1}
+        assert get_file_type_codes_for_format("flac") == {5}
+        assert get_file_type_codes_for_format("WAV") == {11}
+        assert get_file_type_codes_for_format("aiff") == {12}
+        assert get_file_type_codes_for_format("aac") == {4}
+        assert get_file_type_codes_for_format("alac") == {6}
+        assert get_file_type_codes_for_format("mp4") == {3}
+        assert get_file_type_codes_for_format("video") == {16}
+        assert get_file_type_codes_for_format("invalid") == {0}
+
+    def test_m4a_is_not_a_token(self):
+        """Tokens mirror FileType values; the extension-level m4a token was
+        removed, so callers filter AAC/ALAC directly or search by path."""
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_codes_for_format("m4a")
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_file_type_codes_for_format("xyz")
+        with pytest.raises(ValueError, match="cannot be empty"):
+            get_file_type_codes_for_format("")
+
+
+class TestGetExtensionForFormat:
     def test_get_extension_for_format_case_insensitive(self):
         """Test get_extension_for_format is case-insensitive."""
         assert get_extension_for_format("MP3") == ".mp3"
         assert get_extension_for_format("mp3") == ".mp3"
-        assert get_extension_for_format("Mp3") == ".mp3"
         assert get_extension_for_format("FLAC") == ".flac"
-        assert get_extension_for_format("flac") == ".flac"
         assert get_extension_for_format("WAV") == ".wav"
-        assert get_extension_for_format("wav") == ".wav"
-        assert get_extension_for_format("AIFF") == ".aiff"
         assert get_extension_for_format("aiff") == ".aiff"
 
     def test_get_extension_for_format_invalid(self):
         """Test get_extension_for_format with invalid formats."""
-        import pytest
-
-        with pytest.raises(ValueError, match="Unknown format: invalid"):
-            get_extension_for_format("invalid")
-
-        with pytest.raises(ValueError, match="Format name cannot be empty or None"):
+        with pytest.raises(ValueError, match="Unknown format"):
+            get_extension_for_format("xyz")
+        with pytest.raises(ValueError, match="cannot be empty"):
             get_extension_for_format("")
-
-        with pytest.raises(ValueError, match="Format name cannot be empty or None"):
+        with pytest.raises(ValueError, match="cannot be empty"):
             get_extension_for_format(None)  # ty: ignore[invalid-argument-type]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -326,6 +326,48 @@ class TestGetAudioInfo:
         assert result["bitrate"] == 320
         assert result["sample_rate"] == 44100
 
+    @patch("rekordbox_edit.utils.ffmpeg.probe")
+    def test_get_audio_info__codec_and_container(self, mock_probe, ffmpeg_exists):
+        """The probe's codec_name and format_name pass through."""
+        mock_probe.return_value = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "alac",
+                    "bits_per_sample": 16,
+                    "sample_rate": "44100",
+                    "channels": 2,
+                }
+            ],
+            "format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2"},
+        }
+
+        result = get_audio_info("/path/to/audio.m4a")
+
+        assert result["codec"] == "alac"
+        assert result["container"] == "mov,mp4,m4a,3gp,3g2,mj2"
+
+    @patch("rekordbox_edit.utils.ffmpeg.probe")
+    def test_get_audio_info__missing_codec_fields_are_none(
+        self, mock_probe, ffmpeg_exists
+    ):
+        """Probes without codec_name or a format section yield None fields."""
+        mock_probe.return_value = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "bits_per_sample": 16,
+                    "sample_rate": "44100",
+                    "channels": 2,
+                }
+            ]
+        }
+
+        result = get_audio_info("/path/to/audio.wav")
+
+        assert result["codec"] is None
+        assert result["container"] is None
+
 
 class TestConfirm:
     """Test confirm function."""


### PR DESCRIPTION
Resolves #57 

Adds support for displaying and filtering by all known values of Rekordbox's `FileType` column:

| Codec/Container | FileType |
| --- | --- |
| MP3 | 1 |
| m4a (AAC) | 4 |
| m4a (ALAC) | 6 |
| FLAC | 5 |
| WAV | 11 |
| AIFF | 12 |
| mp4* | 3 |
| AVI | 16** |
| M4V | 16** |
| MOV | 16** |
| MPG | 16** |

\* it's possible for mp4 to have a purely ALAC or AAC audio stream and no video stream--rekordbox treats all of these combinations as file type `3` 

** all video containers (other than mp4) are categorized as file type `16` by rekordbox