### PR TITLE
docs: add FAQ about convert's impact on USB exports

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -2,13 +2,13 @@
 
 Messing with your Rekordbox library is bound to raise some questions and concerns, particularly around preserving all the manual work you've done to organize, catalog, and prepare your library for gigs. This page is dedicated to answering those questions around what the impact and risks are of editing your rekordbox library or the underlying audio files using rekordbox-edit. If your question isn't answered here, please ask it in [a discussion](https://github.com/jviall/rekordbox-edit/discussions/new/choose).
 
-## How Does Rekordbox's Analysis Work?
+## How does Rekordbox's analysis work?
 
 Analysis touches two places in your library. The database gets the summary values for things like tempo, key, and the flags Rekordbox uses to track analysis state. The heavier artifacts live in a per-track folder of analysis files (.ANLZ) containing the beat grid, waveforms, and phrase data. Your cues and loops live in neither; they are separate database records that only your own edits change.
 
 What analysis writes is a deterministic estimate. Deterministic, because the same file analyzed twice produces byte-identical results. An estimate, because tempo, grid, and key are inferred from the audio, and Rekordbox's inference is sometimes wrong. Both aspects are worth considering; when the analysis of a converted file produces a different result, it is simply a different estimate from different data.
 
-## How Does Converting a Track Affect the Analysis?
+## How does converting a track affect its analysis?
 
 The reason conversion is safe comes down to how Rekordbox stores analysis: positions are timestamps. The beat grid is a list of times in milliseconds, cues are stored in milliseconds, and phrases are anchored to beats. None of it references sample counts or byte positions in the audio file. Change the codec, the sample rate, or the bit depth, and every stored position still names the same musical moment.
 
@@ -21,19 +21,19 @@ There are a few minor things left stale by a conversion (without any consequence
 
 Converting *to* FLAC does not create that seek index automatically either; only an analysis can. I have *not* tested (yet) whether that matters in practice, but it makes a stronger case for re-analyzing after a conversion to FLAC than for other targets. FLAC also is not the most ideal target format in general for Rekordbox (even though it's preferred for streaming and music hoarders), because only the more recent Pioneer devices support it. AIFF is what I would pick if you insist on lossless.
 
-## Does Converting to MP3 Shift the Audio?
+## Does converting to MP3 shift the audio?
 
 No. `rbe` uses LAME's gapless-playback encoding to avoid any start-of-file offset, and across many tests the MP3 320 output never differed in timing, sample for sample, from its lossless source. Cues and the beat grid stay exactly in register.
 
 The only artifact is visual: the drawn waveform still reflects the lossless original rather than the MP3. A re-analysis would redraw it, but you'd be hard-pressed to notice the difference.
 
-## Will My Cues and Beatgrid Survive?
+## Does convert impact cues or beatgrids?
 
-Yes. Cues, loops, and memory points are records in your library database, positioned in milliseconds and attached to the track's database entry, and `rbe convert` does not touch them. The beat grid lives in the analysis files, which convert also leaves alone. In all my testing, every cue and beat grid has been completely unchanged by a conversion, and works just as it did prior.
+No. Cues, loops, and memory points are records in your library database, positioned in milliseconds and attached to the track's database entry, and `rbe convert` does not touch them. The beat grid lives in the analysis files, which convert also leaves alone. In all my testing, every cue and beat grid has been completely unchanged by a conversion, and works just as it did prior.
 
 This includes hand-tuned grids. Because convert never rewrites the grid a manually corrected beat grid survives conversion unchanged. The one operation that can replace it is a re-analysis you run yourself; see below.
 
-## Should I Re-Analyze After Converting?
+## Should I re-analyze after converting?
 
 You do not need to. The existing analysis remains correct for the converted file, and Rekordbox never re-analyzes on its own; it waits for you to ask. Skipping re-analysis keeps your grid and cues exactly as they are.
 
@@ -41,10 +41,19 @@ If you do re-analyze, the outcome depends on whether the conversion changed the 
 
 One real hazard: re-analysis replaces manually edited beat grids on any track that is not locked. If you plan to re-analyze after a bulk conversion, turn on Analysis Lock first for tracks whose grids you have tuned by hand.
 
-## What Should I Do Before Converting?
+## What if I convert a track that's been exported to a USB?
+
+Conversion only touches your library and the source file--it won't update your USB exports for you. The old version of the track that's on your USB will effectively be orphaned from the library. Depending on the library type (i.e. "Device Library" v.s. "One Device Library") re-syncing will either not do anything, or it will add your new converted versions but leave the stale copies behind. Manually transferring a playlist to a device and overwriting it (by drag-n-dropping in the library explorer tree) will also only add your new versions but not remove the old ones.
+
+Perhaps a more crucial consequence of this orphaning of converted files on your USB, is that any cues, play counts, or other metadata of the converted files that is only on your USB and hasn't been synced back to Rekordbox will also be orphaned, and attempting to sync this back after a conversion won't work.
+
+Ultimately, if you're planning on doing an in-place conversion of tracks in your library using this tool, you should consider making sure the cues, grid, and info on your USB sticks has been synced back to Rekordbox (if so desired), and be prepared to erase and freshly export your USBs in order to avoid any stale files left behind by a re-export.
+
+## What should I do before converting?
 
 - **Preview with `--dry-run`.** See exactly which tracks will convert and where the files will go before anything is written.
 - **Close Rekordbox.** Writing to the database while Rekordbox has it open risks corruption.
-- **Make fresh backups of your music and your Rekordbox database.** Conversion rewrites files and database rows in place; a current backup makes any surprise reversible.
+- **Make fresh backups of your music and your Rekordbox database.** Conversion rewrites files and database rows in place; a current backup makes any mistake reversible.
+- **Sync back cues, grids, and info from your USBs** Converting a track that has been exported will orphan the exported version and any un-synced metadata from your library.
 - **Keep your originals until you are satisfied.** The default `--delete-originals lossless` only deletes a source when no audio information was lost. Be deliberate before choosing `all`.
 - **Lock hand-tuned beat grids if you plan to re-analyze.** Conversion won't mess with your grids, but a later bulk re-analysis replaces grids on unlocked tracks. Analysis Lock exists for exactly this.

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,8 +8,8 @@
     ":enablePreCommit",
     ":automergePr",
     "helpers:pinGitHubActionDigests",
-    "schedule:daily",
-    "schedule:automergeDaily",
+    "schedule:weekends",
+    "schedule:automergeEarlyMondays",
   ],
 
   branchPrefix: "chore/deps/",


### PR DESCRIPTION
Adds an FAQ entry on converting a track that's already exported to a USB.

## Research
Ran a three-round experiment against a real export on a thumb drive. I snapshotted and diffed three layers of data at each step — the master.db rows/cues, the device's audio contents, and the device's databases — before and after each convert, re-export, and sync-back. 

Read the device side directly: ANLZ cue lists via pyrekordbox, plus the decrypted exportLibrary.db (Device Library Plus) content/cue/history tables. Each round used a control fixture (edited on the player but not converted) to isolate convert as the cause. Round 1 covered a simple re-export; Rounds 2 and 3 covered sync-back on an XDJ-700 ("Device Library") and an XDJ-AZ ("OneLibrary"), respectively.

## Findings

- Re-export doesn't cleanly replace the exported file. Depending on library type, a re-sync either no-ops or copies the converted file and leaves the original orphaned; a manual drag-to-overwrite also only adds, never removes.
- Edits made on the player don't sync back if the track was converted after export. Cues and play counts are silently dropped — reproduced on both library export types. The controls synced fine, so the cause is the convert. Rekordbox seems to gate the sync on the device file still matching the collection file (even though exports also contain library IDs of tracks) and a conversion changes the format/path enough to fail the match.