### PR TITLE
feat!: replace --exact-path with case-insensitive --resolved-path

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -18,14 +18,16 @@ Repeating a filter, or combining different filters, matches tracks that satisfy 
 | `--playlist TEXT` | playlist name contains `TEXT` |
 | `--exact-playlist TEXT` | playlist name is exactly `TEXT` |
 | `--format FMT` | Rekordbox file type is `FMT` (`mp3`, `mp4`, `aac`, `flac`, `alac`, `wav`, `aiff`, `video`, `invalid`) |
-| `--path TEXT` | file path contains `TEXT` (matched against the folder path, filename, or both) |
-| `--exact-path TEXT` | file path is exactly `TEXT` (resolved to an absolute path before matching) |
+| `--path TEXT` | file path contains `TEXT`, case-insensitive |
+| `--resolved-path TEXT` | file path contains `TEXT` after resolving it to an absolute path, case-insensitive |
 | `--first N` | return only the first N results |
 | `--last N` | return only the last N results |
 
 > [!TIP]
 > Filters that are "exact" are case-sensitive (e.g. `--exact-artist 'HOOBASTANK'` won't match "Hoobastank") whereas their counterparts (`--artist`) are case-insensitive and match substrings. Only one of either the `--first` and `--last` filters can be provided at a time as they're mutually exclusive.
 
+> [!NOTE]
+> Path filters match case-insensitively on every platform because the filesystems Rekordbox supports (NTFS and APFS) treat paths case-insensitively themselves.
 
 ### Examples
 
@@ -45,11 +47,14 @@ rbe search --playlist "house" --playlist "disco"
 # All the songs in my library that aren't in any playlist
 rbe search --playlist ""
 
-# The first 10 tracks whose path contains a folder or filename substring
+# The first 10 tracks in a "Favorites" folder or with "track.wav" in the file path
 rbe search --path "Favorites/" --path "track.wav" --first 10
 
 # The track at an exact location
-rbe search --exact-path "/Users/djmustard/Music/banger.mp3"
+rbe search --resolved-path "/Users/djmustard/Music/banger.mp3"
+
+# Every track under a folder, given relative to the current directory
+rbe search --resolved-path "../Music/house/"
 ```
 
 ## Track ID Arguments

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -81,13 +81,14 @@ global_click_filters = [
         "--path",
         type=str,
         multiple=True,
-        help="Find tracks whose file paths include this value",
+        help="Find tracks whose file paths contain this value (case-insensitive)",
     ),
     click.option(
-        "--exact-path",
+        "--resolved-path",
         type=str,
         multiple=True,
-        help="Find tracks whose file paths are exactly this value",
+        help="Find tracks whose file paths contain this value after it is "
+        "resolved to an absolute path (case-insensitive)",
     ),
     click.option(
         "--format",

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -74,7 +74,7 @@ def _narrow_to_track_ids(args, ids: list[str]):
         "album",
         "exact_album",
         "path",
-        "exact_path",
+        "resolved_path",
         "format",
     ):
         if hasattr(narrowed, field_name):

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -45,7 +45,7 @@ class FilterArgs(BaseModel):
     album: list[str] = []
     exact_album: list[str] = []
     path: list[str] = []
-    exact_path: list[str] = []
+    resolved_path: list[str] = []
     format: list[str] = []
     first: int | None = Field(default=None, gt=0)
     last: int | None = Field(default=None, gt=0)

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import List, Tuple, Union
 
@@ -148,57 +149,32 @@ class CollectionQuery:
             logger.warning(f"Invalid format: {format_name}")
         return new_inst
 
-    def by_path(self, path_str: str, exact: bool = False) -> "CollectionQuery":
-        """Filter by file path, matching against FolderPath and/or FileNameL.
+    def by_path(self, path_str: str, resolved: bool = False) -> "CollectionQuery":
+        """Filter by case-insensitive substring of the track's file path.
+        FolderPath holds the full path to the file, including its name and
+        extension.
 
-        Paths get normalized to posix format.
-        --path args arg matched as substrings.
-        --exact-path argsl are resolved to absolute paths and must match exact.
-
-        Args with a trailing '/' only query against FolderPath.
-        Args with no parent folders in the path only query against FileNameL.
+        Separators get normalized to posix format, and a trailing '/' is kept
+        so the substring only matches directory components.
+        --path args match as given.
+        --resolved-path args are made absolute against the working directory
+        by pure string math (no filesystem access), so casing stays as typed
+        and symlinks are never followed.
         """
+        if not path_str:
+            return self
+
         new_inst = self._copy()
+        has_trailing_sep = path_str.endswith(("/", "\\"))
 
-        is_dir_only = path_str.endswith("/") or path_str.endswith("\\")
-
-        if exact:
-            resolved = Path(path_str).resolve()
-            if is_dir_only:
-                folder_part = resolved.as_posix() + "/"
-                name_part = ""
-            elif "/" not in path_str and "\\" not in path_str:
-                folder_part = ""
-                name_part = resolved.name
-            else:
-                folder_part = resolved.parent.as_posix() + "/"
-                name_part = resolved.name
+        if resolved:
+            pattern = Path(os.path.abspath(path_str)).as_posix()
+            if has_trailing_sep and not pattern.endswith("/"):
+                pattern += "/"
         else:
-            normalized = Path(path_str)
-            if is_dir_only:
-                folder_part = normalized.as_posix()
-                name_part = ""
-            else:
-                parent_str = normalized.parent.as_posix()
-                folder_part = "" if parent_str == "." else parent_str
-                name_part = normalized.name
+            pattern = path_str.replace("\\", "/")
 
-        conditions: list[ColumnElement[bool]] = []
-        if folder_part:
-            if exact:
-                conditions.append(DjmdContent.FolderPath == folder_part)
-            else:
-                conditions.append(DjmdContent.FolderPath.ilike(f"%{folder_part}%"))
-        if name_part:
-            if exact:
-                conditions.append(DjmdContent.FileNameL == name_part)
-            else:
-                conditions.append(DjmdContent.FileNameL.ilike(f"%{name_part}%"))
-
-        if conditions:
-            combined = and_(*conditions) if len(conditions) > 1 else conditions[0]
-            new_inst._conditions.append(combined)
-
+        new_inst._conditions.append(DjmdContent.FolderPath.ilike(f"%{pattern}%"))
         return new_inst
 
     def limit(self, count: int) -> "CollectionQuery":
@@ -317,8 +293,8 @@ def get_filtered_content(
     for path in filters.path:
         query = query.by_path(path)
 
-    for exact_path in filters.exact_path:
-        query = query.by_path(exact_path, exact=True)
+    for resolved_path in filters.resolved_path:
+        query = query.by_path(resolved_path, resolved=True)
 
     if filters.match_all:
         query = query.match_all()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -468,58 +468,44 @@ class TestCollectionQuery:
         assert " and " in stmt_str
         assert " or " not in stmt_str
 
-    def test_by_path_filename_only(self):
-        """A bare filename (no directory) adds a FileNameL ilike condition only.
-        The FolderPath condition is skipped — the filter still runs with just FileNameL.
-        """
+    def test_by_path_substring_against_folderpath_only(self):
+        """A --path arg adds a single case-insensitive substring condition on
+        FolderPath, which holds the full file path. FileNameL is never queried."""
+        query = CollectionQuery()
+        new_query = query.by_path("Daft Punk")
+
+        assert new_query is not query
+        assert len(new_query._conditions) == 1
+        condition_str = str(new_query._conditions[0])
+        assert "FolderPath" in condition_str
+        assert "FileNameL" not in condition_str
+        assert "LIKE lower" in condition_str
+
+    def test_by_path_wraps_with_wildcards(self):
+        """The substring pattern is wrapped in % wildcards."""
         query = CollectionQuery()
         new_query = query.by_path("track.mp3")
 
-        assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
-        assert "FileNameL" in condition_str
-        assert "LIKE lower" in condition_str
-        assert "FolderPath" not in condition_str
+        condition_str = _compile(new_query._conditions[0])
+        assert "%track.mp3%" in condition_str
 
-    def test_by_path_folder_only_forward_slash(self):
-        """A trailing-forward-slash string adds a FolderPath ilike condition only.
-        The FileNameL condition is skipped — the filter still runs with just FolderPath.
-        """
+    def test_by_path_preserves_trailing_slash(self):
+        """A trailing slash stays in the pattern so it only matches directory
+        components, not filename prefixes."""
         query = CollectionQuery()
-        new_query = query.by_path("./Test/Folder/")
+        new_query = query.by_path("Daft Punk/")
 
-        assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
-        assert "FileNameL" not in condition_str
-        assert "LIKE lower" in condition_str
-        assert "FolderPath" in condition_str
+        condition_str = _compile(new_query._conditions[0])
+        assert "%Daft Punk/%" in condition_str
 
-    def test_by_path_folder_and_filename(self):
-        """A path with both parts adds a compound AND condition covering both columns."""
-        query = CollectionQuery()
-        new_query = query.by_path("Music/Artist/track.mp3")
-
-        assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
-        assert "FolderPath" in condition_str
-        assert "FileNameL" in condition_str
-        assert " AND " in condition_str
-        assert condition_str.count("LIKE lower") == 2
-
-    @pytest.mark.skipif(
-        platform.system() != "Windows", reason="backslash path parsing is Windows-only"
-    )
     def test_by_path_backslash_normalised_to_forward_slash(self):
         """Backslash separators in --path input are normalised to forward slashes."""
         query = CollectionQuery()
-        new_query = query.by_path("Music\\Artist\\track.mp3")
+        new_query = query.by_path("Music\\Artist\\")
 
-        query_str = _compile(new_query._conditions[0])
-        assert "\\" not in query_str
-        assert "Music/Artist" in query_str
+        condition_str = _compile(new_query._conditions[0])
+        assert "\\" not in condition_str
+        assert "%Music/Artist/%" in condition_str
 
     def test_by_path_no_resolve(self):
         """by_path does NOT resolve the path."""
@@ -530,87 +516,83 @@ class TestCollectionQuery:
         # The raw string (or parts of it) must appear, not a resolved absolute path
         assert ".." in condition_str and "relative" in condition_str
 
-    def test_by_path_ilike_wraps_with_wildcards(self):
-        """The ilike condition includes % wildcards for substring matching."""
+    def test_by_path_empty_arg_adds_no_condition(self):
+        """An empty --path arg is a no-op rather than matching everything."""
         query = CollectionQuery()
-        new_query = query.by_path("track.mp3")
+        new_query = query.by_path("")
 
-        condition_str = _compile(new_query._conditions[0])
-        assert "%" in condition_str
+        assert new_query._conditions == []
 
-    # --- by_path exact mode ---
+    # --- by_path resolved mode ---
 
-    def test_by_exact_path_filename_only(self):
-        """Exact match on a bare filename produces an equality condition on FileNameL only."""
-        query = CollectionQuery()
-        new_query = query.by_path("track.mp3", exact=True)
-
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
-        assert "FolderPath" not in condition_str
-        assert "FileNameL" in condition_str
-        assert "=" in condition_str
-        assert "LIKE lower" not in condition_str
-
-    def test_by_exact_path_folder_only(self):
-        """Exact match on a only folder path produces equality check on FolderPath only."""
-        query = CollectionQuery()
-        # Build a cross-platform absolute path using pathlib
-        path = "/Test/Artist/"
-        new_query = query.by_path(path, exact=True)
-
-        assert len(new_query._conditions) == 1
-        condition_str = _compile(new_query._conditions[0])
-        assert "FolderPath" in condition_str
-        assert "FileNameL" not in condition_str
-        assert "=" in condition_str
-        assert path in condition_str
-        assert "like lower" not in condition_str
-
-    def test_by_exact_path_folder_and_filename(self):
-        """Exact match on a full path produces a compound AND with equality on both columns."""
-        query = CollectionQuery()
-        # Build a cross-platform absolute path using pathlib
-        abs_path = "/Artist/track.mp3"
-        new_query = query.by_path(abs_path, exact=True)
-
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
-        assert "FolderPath" in condition_str
-        assert "FileNameL" in condition_str
-        assert " AND " in condition_str
-        assert "LIKE lower" not in condition_str
-
-    def test_by_exact_path_resolves_relative_path(self):
-        """Exact match resolves relative paths to absolute before querying."""
+    def test_by_resolved_path_resolves_relative_path(self):
+        """Resolved mode makes relative paths absolute against the cwd before querying."""
         cwd = Path(os.getcwd()).as_posix()
         query = CollectionQuery()
-        new_query = query.by_path("Album/track.mp3", exact=True)
+        new_query = query.by_path("Album/track.mp3", resolved=True)
 
         condition_str = _compile(new_query._conditions[0])
-        # cwd should appear as the resolved folder part
-        assert cwd in condition_str
+        assert f"%{cwd}/Album/track.mp3%" in condition_str
+
+    def test_by_resolved_path_substring_case_insensitive(self):
+        """Resolved mode is a case-insensitive substring check on FolderPath,
+        same as fuzzy mode, so a resolved folder path matches every track under it."""
+        query = CollectionQuery()
+        new_query = query.by_path("/Test/Artist/file.mp3", resolved=True)
+
+        assert len(new_query._conditions) == 1
+        condition_str = str(new_query._conditions[0])
+        assert "FolderPath" in condition_str
+        assert "FileNameL" not in condition_str
+        assert "LIKE lower" in condition_str
+
+    def test_by_resolved_path_is_lexical_and_preserves_casing(self):
+        """Resolution is pure string math: even for a directory that exists on
+        disk, the casing stays as typed instead of being rewritten to the
+        on-disk casing (Path.resolve would rewrite it on Windows)."""
+        miscased_cwd = Path(os.getcwd()).as_posix().swapcase()
+        query = CollectionQuery()
+        new_query = query.by_path(f"{miscased_cwd}/track.mp3", resolved=True)
+
+        condition_str = _compile(new_query._conditions[0])
+        assert f"{miscased_cwd}/track.mp3" in condition_str
+
+    def test_by_resolved_path_preserves_trailing_slash(self):
+        """A trailing slash survives resolution so the pattern only matches
+        directory components."""
+        query = CollectionQuery()
+        new_query = query.by_path("Album/", resolved=True)
+
+        condition_str = _compile(new_query._conditions[0])
+        assert f"{Path(os.getcwd()).as_posix()}/Album/" in condition_str
 
     @pytest.mark.skipif(
         platform.system() != "Windows", reason="backslash path parsing is Windows-only"
     )
-    def test_by_exact_path_backslash_normalised_to_forward_slash(self):
-        """Backslash separators in --exact-path input are normalised via as_posix()."""
+    def test_by_resolved_path_backslash_normalised_to_forward_slash(self):
+        """Backslash separators in --resolved-path input are normalised via as_posix()."""
         query = CollectionQuery()
         # Pass a Windows-style absolute path; as_posix() must produce forward slashes
         new_query = query.by_path(
-            "C:\\Users\\foo\\music\\Artist\\track.mp3", exact=True
+            "C:\\Users\\foo\\music\\Artist\\track.mp3", resolved=True
         )
 
         condition_str = _compile(new_query._conditions[0])
         assert "\\" not in condition_str
-        assert "/" in condition_str
+        assert "C:/Users/foo/music/Artist/track.mp3" in condition_str
+
+    def test_by_resolved_path_empty_arg_adds_no_condition(self):
+        """An empty --resolved-path arg is a no-op rather than matching everything."""
+        query = CollectionQuery()
+        new_query = query.by_path("", resolved=True)
+
+        assert new_query._conditions == []
 
     def test_by_path_returns_new_instance(self):
         """by_path always returns a new CollectionQuery instance."""
         query = CollectionQuery()
         assert query.by_path("track.mp3") is not query
-        assert query.by_path("track.mp3", exact=True) is not query
+        assert query.by_path("track.mp3", resolved=True) is not query
 
 
 @pytest.fixture
@@ -699,9 +681,9 @@ class TestGetFilteredContent:
         get_filtered_content(mock_db, FilterArgs(path=["Music/track.mp3"]))
         mock_query.by_path.assert_called_once_with("Music/track.mp3")
 
-    def test_exact_path(self, mock_db, mock_query):
-        get_filtered_content(mock_db, FilterArgs(exact_path=["/Music/track.wav"]))
-        mock_query.by_path.assert_called_once_with("/Music/track.wav", exact=True)
+    def test_resolved_path(self, mock_db, mock_query):
+        get_filtered_content(mock_db, FilterArgs(resolved_path=["/Music/track.wav"]))
+        mock_query.by_path.assert_called_once_with("/Music/track.wav", resolved=True)
 
     def test_format(self, mock_db, mock_query):
         get_filtered_content(mock_db, FilterArgs(format=["flac"]))


### PR DESCRIPTION
With Path.resolve() and attempting to make the `--exact-path` arg case-sensitive, we were creating platform-dependent edge cases. Like if a path on disk in a windows OS had a different casing that was passed, Path.resolve() would correct the casing, and if the Rekordbox library would have otherwise matched the original path it would silently not return that result. If that same disk wasn't mounted at the time of running, then Path.resolve() *wouldn't* correct the casing, and rbe would return the matching result.

With `--resolve-path`, path filters now always match case-insensitively, mirroring how NTFS and APFS treat paths. --resolved-path makes its argument absolute by pure string math instead of Path.resolve(), so results no longer depend on mounted drives, on-disk casing, or symlinks. Also `--path` now matches against any sub-string part of the FolderName column.