### PR TITLE
feat!: adds new default filtering mode `grouped`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: check-toml
     -   id: check-case-conflict
 -   repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.17.0
+    rev: v4.18.0
     hooks:
     -   id: commitizen
         stages: [commit-msg]
@@ -32,7 +32,7 @@ repos:
         files: pyproject\.toml$
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.3
+    rev: v0.16.4
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: check-toml
     -   id: check-case-conflict
 -   repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.18.0
+    rev: v4.17.0
     hooks:
     -   id: commitizen
         stages: [commit-msg]
@@ -32,7 +32,7 @@ repos:
         files: pyproject\.toml$
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.4
+    rev: v0.16.3
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,12 @@ from rekordbox_edit.api import search
 from rekordbox_edit.models import SearchRequest
 
 db = Rekordbox6Database()
-response = search(db, SearchRequest(artist=["Daft Punk"], format=["flac"], match_all=True))
+response = search(db, SearchRequest(artist=["Daft Punk"], format=["flac"]))
 for track in response.tracks:
     print(track.ID, track.Title)
 ```
+
+Different filter kinds — `artist` and `format` above — AND together by default; repeated values of the same filter OR together. Pass `match_all=True` to flatten everything into one AND, or `match_any=True` to flatten everything into one OR.
 
 `--print json` on any CLI command emits exactly these response envelopes, so the models below also document the JSON you get when scripting.
 
@@ -28,65 +30,65 @@ for track in response.tracks:
 The models form three layers: the [`FilterArgs`][rekordbox_edit.models.FilterArgs] base that every command shares, the per-command requests and responses, and the lower-level domain types those req/resp models are built from.
 
 ::: rekordbox_edit.models.FilterArgs
-    options:
-      heading_level: 3
+options:
+heading_level: 3
 
 ### Search
 
 ::: rekordbox_edit.models.SearchRequest
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.SearchResponse
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ### Edit
 
 ::: rekordbox_edit.models.EditRequest
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.EditResponse
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.EditResult
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ### Convert
 
 ::: rekordbox_edit.models.ConvertRequest
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.ConvertResponse
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.ConvertResult
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ### Miscellaneous
 
 ::: rekordbox_edit.models.Track
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.EditOp
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.ConvertOp
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.SkippedTrack
-    options:
-      heading_level: 4
+options:
+heading_level: 4
 
 ::: rekordbox_edit.models.SkipReason
-    options:
-      heading_level: 4
+options:
+heading_level: 4

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -11,8 +11,8 @@ rbe search --artist "Aphex Twin" --format flac
 # Get all the track IDs in a playlist
 rbe search --playlist "Techno" --print ids
 
-# Find tracks matching ALL filters (AND logic)
-rbe search --artist "Burial" --album "Untrue" --match-all
+# Tracks that are either flac, or in this playlist
+rbe search --playlist "Techno" --format flac --match-any
 
 # Feed results to another command
 rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
@@ -23,7 +23,7 @@ See [Filtering](../filtering.md) for the full filter language and piping recipes
 ## Reference
 
 ::: mkdocs-click
-    :module: rekordbox_edit.cli.search
-    :command: search_command
-    :prog_name: rbe search
-    :depth: 1
+:module: rekordbox_edit.cli.search
+:command: search_command
+:prog_name: rbe search
+:depth: 1

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -4,27 +4,27 @@ Every command supports filtering by all of the [`FilterArgs`][rekordbox_edit.mod
 
 ## Filter Options
 
-Repeating a filter, or combining different filters, matches tracks that satisfy *any* of the provided filters. Pass `--match-all` to require *every* filter to match.
+By default any filters provided are grouped by kind: repeating the _same_ filter with different values matches tracks that satisfy _any_ of those values (an OR), while combining _different_ filters narrows to tracks that satisfy every one of them (an AND). Pass `--match-all` to find results that match each and every filter value. Pass `--match-any` to instead match tracks that satisfy any single filter value provided.
 
-| Option | Matches tracks whose... |
-| --- | --- |
-| `--track-id ID` | database track ID equals `ID` |
-| `--title TEXT` | title contains `TEXT` |
-| `--exact-title TEXT` | title is exactly `TEXT` |
-| `--artist TEXT` | artist name contains `TEXT` |
-| `--exact-artist TEXT` | artist name is exactly `TEXT` |
-| `--album TEXT` | album name contains `TEXT` |
-| `--exact-album TEXT` | album name is exactly `TEXT` |
-| `--playlist TEXT` | playlist name contains `TEXT` |
-| `--exact-playlist TEXT` | playlist name is exactly `TEXT` |
-| `--format FMT` | Rekordbox file type is `FMT` (`mp3`, `mp4`, `aac`, `flac`, `alac`, `wav`, `aiff`, `video`, `invalid`) |
-| `--path TEXT` | file path contains `TEXT`, case-insensitive |
-| `--resolved-path TEXT` | file path contains `TEXT` after resolving it to an absolute path, case-insensitive |
-| `--first N` | return only the first N results |
-| `--last N` | return only the last N results |
+| Option                  | Matches tracks whose...                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--track-id ID`         | database track ID equals `ID`                                                                         |
+| `--title TEXT`          | title contains `TEXT`                                                                                 |
+| `--exact-title TEXT`    | title is exactly `TEXT`                                                                               |
+| `--artist TEXT`         | artist name contains `TEXT`                                                                           |
+| `--exact-artist TEXT`   | artist name is exactly `TEXT`                                                                         |
+| `--album TEXT`          | album name contains `TEXT`                                                                            |
+| `--exact-album TEXT`    | album name is exactly `TEXT`                                                                          |
+| `--playlist TEXT`       | playlist name contains `TEXT`                                                                         |
+| `--exact-playlist TEXT` | playlist name is exactly `TEXT`                                                                       |
+| `--format FMT`          | Rekordbox file type is `FMT` (`mp3`, `mp4`, `aac`, `flac`, `alac`, `wav`, `aiff`, `video`, `invalid`) |
+| `--path TEXT`           | file path contains `TEXT`, case-insensitive                                                           |
+| `--resolved-path TEXT`  | file path contains `TEXT` after resolving it to an absolute path, case-insensitive                    |
+| `--first N`             | return only the first N results                                                                       |
+| `--last N`              | return only the last N results                                                                        |
 
 > [!TIP]
-> Filters that are "exact" are case-sensitive (e.g. `--exact-artist 'HOOBASTANK'` won't match "Hoobastank") whereas their counterparts (`--artist`) are case-insensitive and match substrings. Only one of either the `--first` and `--last` filters can be provided at a time as they're mutually exclusive.
+> Filters that are "exact" are case-sensitive (e.g. `--exact-artist 'HOOBASTANK'` won't match "Hoobastank") whereas their counterparts (`--artist`) are case-insensitive and match substrings.
 
 > [!NOTE]
 > Path filters match case-insensitively on every platform because the filesystems Rekordbox supports (NTFS and APFS) treat paths case-insensitively themselves.
@@ -32,23 +32,29 @@ Repeating a filter, or combining different filters, matches tracks that satisfy 
 ### Examples
 
 ```bash
-# Tracks by either artist
+# Tracks by either artist (repeated filters OR together, by default)
 rbe search --artist "Daft Punk" --artist "Justice"
 
-# Tracks matching artist AND format
-rbe search --artist "Aphex Twin" --format flac --match-all
+# Tracks matching artist AND format (different filters AND together, by default)
+rbe search --artist "Aphex Twin" --format flac
+
+# Tracks that are either flac, or by Aphex Twin
+rbe search --artist "Aphex Twin" --format flac --match-any
+
+# Tracks that match both Tom Petty and The Heartbreakers
+rbe search --artist "Tom Petty" --artist "The Heartbreakers" --match-all
 
 # All the songs in this playlist
 rbe search --exact-playlist "Main Room 2024"
 
-# All the songs in all my "house" or "disco" playlists
+# All the songs in any "house" or "disco" playlists
 rbe search --playlist "house" --playlist "disco"
 
 # All the songs in my library that aren't in any playlist
 rbe search --playlist ""
 
-# The first 10 tracks in a "Favorites" folder or with "track.wav" in the file path
-rbe search --path "Favorites/" --path "track.wav" --first 10
+# The first 10 tracks that either live under a "Favorites" folder or have the word "remix" somewhere in the file path
+rbe search --path "Favorites/" --path "remix" --first 10
 
 # The track at an exact location
 rbe search --resolved-path "/Users/djmustard/Music/banger.mp3"
@@ -90,23 +96,13 @@ All commands take `--print [silent|ids|info|debug|json]`:
 rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
 ```
 
-Piping allows you to compose OR and AND logic that a single command could not express by itself:
-
-**AND-narrowing** — pipe a broad OR result into a second command with `--match-all` to intersect:
-
-```bash
-# Search all (Daft Punk OR Justice) AND flac
-rbe search --artist "Daft Punk" --artist "Justice" --print ids \
-  | rbe search --format flac --match-all
-```
-
 **OR between AND-groups** — merge results from two commands using a subshell:
 
 ```bash
 # Convert all (Daft Punk AND flac) OR (Justice AND aiff)
-{ rbe search --artist "Daft Punk" --format flac --match-all --print ids; \
-  rbe search --artist "Justice" --format aiff --match-all --print ids; } \
+{ rbe search --artist "Daft Punk" --format flac --print ids; \
+  rbe search --artist "Justice" --format aiff --print ids; } \
   | rbe convert --format-out mp3 --dry-run
 ```
 
-For richer pipelines, `--print json` emits the same selection as structured data for `jq` and other shell tools. Use the [API functions](api.md#functions) if you want to build a more complex python script.
+For richer pipelines, `--print json` emits the same selection as a structured database dump for `jq` and other shell tools. Use the [API functions](api.md#functions) if you want to build a more complex python script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ exclude-newer = "3 days"
 
 [tool.coverage.run]
 branch = true
+omit = [
+  "research"
+]
 data_file = ".coverage/coverage.db"
 [tool.coverage.html]
 directory = ".coverage/html/"
@@ -77,6 +80,9 @@ python-version = "3.11"
 
 [tool.ty.analysis]
 allowed-unresolved-imports = ["pyrekordbox", "ffmpeg"]
+
+[tool.ty.src]
+exclude = ["research/"]
 
 [tool.commitizen]
 name = "cz_customize"

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -115,7 +115,13 @@ global_click_filters = [
         "--match-all",
         type=bool,
         is_flag=True,
-        help="Results must match all given filters",
+        help="Flatten every filter value, including repeats, into one AND",
+    ),
+    click.option(
+        "--match-any",
+        type=bool,
+        is_flag=True,
+        help="Flatten every filter value into one OR, ignoring the default grouping",
     ),
 ]
 

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -81,6 +81,7 @@ def _narrow_to_track_ids(args, ids: list[str]):
             setattr(narrowed, field_name, [])
     narrowed.track_ids = list(ids)
     narrowed.match_all = False
+    narrowed.match_any = False
     narrowed.first = None
     narrowed.last = None
     return narrowed

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -50,11 +50,24 @@ class FilterArgs(BaseModel):
     first: int | None = Field(default=None, gt=0)
     last: int | None = Field(default=None, gt=0)
     match_all: bool = False
+    """Flatten every filter condition, including repeated values of the same
+    filter, into one AND. Mutually exclusive with match_any. By default
+    (neither set), repeated values of the same filter OR together and
+    different filters AND together."""
+    match_any: bool = False
+    """Flatten every filter condition into one OR, matching tracks that
+    satisfy any single filter value. Mutually exclusive with match_all."""
 
     @model_validator(mode="after")
     def _check_first_last_exclusive(self) -> "FilterArgs":
         if self.first is not None and self.last is not None:
             raise ValueError("'first' and 'last' are mutually exclusive")
+        return self
+
+    @model_validator(mode="after")
+    def _check_match_mode_exclusive(self) -> "FilterArgs":
+        if self.match_all and self.match_any:
+            raise ValueError("'match_all' and 'match_any' are mutually exclusive")
         return self
 
 

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -50,13 +50,7 @@ class FilterArgs(BaseModel):
     first: int | None = Field(default=None, gt=0)
     last: int | None = Field(default=None, gt=0)
     match_all: bool = False
-    """Flatten every filter condition, including repeated values of the same
-    filter, into one AND. Mutually exclusive with match_any. By default
-    (neither set), repeated values of the same filter OR together and
-    different filters AND together."""
     match_any: bool = False
-    """Flatten every filter condition into one OR, matching tracks that
-    satisfy any single filter value. Mutually exclusive with match_all."""
 
     @model_validator(mode="after")
     def _check_first_last_exclusive(self) -> "FilterArgs":

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Literal, Tuple, Union
 
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6.tables import (
@@ -18,35 +18,47 @@ from rekordbox_edit.models import FilterArgs
 
 logger = logging.getLogger(__name__)
 
+MatchMode = Literal["grouped", "all", "any"]
+
 
 class CollectionQuery:
-    def __init__(self, match_all=False):
+    def __init__(self, mode: MatchMode = "grouped"):
         self._stmt = select(DjmdContent)
-        self._conditions: list[ColumnElement[bool]] = []
+        self._conditions: dict[str, list[ColumnElement[bool]]] = {}
         self._limit_count = None
         self._last_count = None
-        self._match_all = match_all
+        self._mode: MatchMode = mode
+
+    @property
+    def _flat_conditions(self) -> list[ColumnElement[bool]]:
+        """Every condition across every filter-kind bucket, as one flat list."""
+        return [c for conditions in self._conditions.values() for c in conditions]
 
     def _copy(self) -> "CollectionQuery":
         """Create a copy of this query in its current state."""
         new_inst = CollectionQuery.__new__(CollectionQuery)
         new_inst._stmt = self._stmt._clone()
-        new_inst._conditions = self._conditions.copy()
+        new_inst._conditions = {
+            group: conditions.copy() for group, conditions in self._conditions.items()
+        }
         new_inst._limit_count = self._limit_count
         new_inst._last_count = self._last_count
-        new_inst._match_all = self._match_all
+        new_inst._mode = self._mode
         return new_inst
 
+    def _append_condition(self, group: str, condition: ColumnElement[bool]) -> None:
+        self._conditions.setdefault(group, []).append(condition)
+
     def match_any(self) -> "CollectionQuery":
-        """Set the filter combination logic to use the OR operator (the default)."""
+        """Flatten every condition, across every filter kind, into one OR."""
         new_inst = self._copy()
-        new_inst._match_all = False
+        new_inst._mode = "any"
         return new_inst
 
     def match_all(self) -> "CollectionQuery":
-        """Set the filter combination logic to use the AND operator."""
+        """Flatten every condition, across every filter kind, into one AND."""
         new_inst = self._copy()
-        new_inst._match_all = True
+        new_inst._mode = "all"
         return new_inst
 
     def by_track_ids(self, track_ids: Union[str, List[str]]) -> "CollectionQuery":
@@ -54,7 +66,7 @@ class CollectionQuery:
         new_inst = self._copy()
         if isinstance(track_ids, str):
             track_ids = [track_ids]
-        new_inst._conditions.append(DjmdContent.ID.in_(track_ids))
+        new_inst._append_condition("track_id", DjmdContent.ID.in_(track_ids))
         return new_inst
 
     def by_artist(self, artist_name: str, exact: bool = False) -> "CollectionQuery":
@@ -73,7 +85,7 @@ class CollectionQuery:
         else:
             condition = ArtistAlias.Name.ilike(f"%{artist_name}%")
 
-        new_inst._conditions.append(condition)
+        new_inst._append_condition("artist", condition)
         return new_inst
 
     def by_title(self, title: str, exact: bool = False) -> "CollectionQuery":
@@ -88,7 +100,7 @@ class CollectionQuery:
         else:
             condition = DjmdContent.Title.ilike(f"%{title}%")
 
-        new_inst._conditions.append(condition)
+        new_inst._append_condition("title", condition)
         return new_inst
 
     def by_album(self, album_name: str, exact: bool = False) -> "CollectionQuery":
@@ -107,7 +119,7 @@ class CollectionQuery:
         else:
             condition = AlbumAlias.Name.ilike(f"%{album_name}%")
 
-        new_inst._conditions.append(condition)
+        new_inst._append_condition("album", condition)
         return new_inst
 
     def by_playlist(self, playlist_name: str, exact: bool = False) -> "CollectionQuery":
@@ -128,7 +140,7 @@ class CollectionQuery:
         else:
             condition = PlaylistAlias.Name.ilike(f"%{playlist_name}%")
 
-        new_inst._conditions.append(condition)
+        new_inst._append_condition("playlist", condition)
         return new_inst
 
     def by_format(self, format_name: str) -> "CollectionQuery":
@@ -144,7 +156,7 @@ class CollectionQuery:
         try:
             file_type_codes = get_file_type_codes_for_format(format_name)
             condition = DjmdContent.FileType.in_(file_type_codes)
-            new_inst._conditions.append(condition)
+            new_inst._append_condition("format", condition)
         except ValueError:
             logger.warning(f"Invalid format: {format_name}")
         return new_inst
@@ -174,7 +186,7 @@ class CollectionQuery:
         else:
             pattern = path_str.replace("\\", "/")
 
-        new_inst._conditions.append(DjmdContent.FolderPath.ilike(f"%{pattern}%"))
+        new_inst._append_condition("path", DjmdContent.FolderPath.ilike(f"%{pattern}%"))
         return new_inst
 
     def limit(self, count: int) -> "CollectionQuery":
@@ -214,14 +226,24 @@ class CollectionQuery:
         stmt = self._stmt
 
         if self._conditions:
-            logic = "AND" if self._match_all else "OR"
-            logger.debug(
-                f"Building query with {len(self._conditions)} condition(s) using {logic} logic"
-            )
-            if self._match_all:
-                combined_condition = and_(*self._conditions)
+            if self._mode == "all":
+                logger.debug(
+                    f"Building query with {len(self._flat_conditions)} condition(s) using flat AND logic"
+                )
+                combined_condition = and_(*self._flat_conditions)
+            elif self._mode == "any":
+                logger.debug(
+                    f"Building query with {len(self._flat_conditions)} condition(s) using flat OR logic"
+                )
+                combined_condition = or_(*self._flat_conditions)
             else:
-                combined_condition = or_(*self._conditions)
+                logger.debug(
+                    f"Building query with {len(self._conditions)} filter group(s) using grouped AND-of-OR logic"
+                )
+                group_conditions = [
+                    or_(*conditions) for conditions in self._conditions.values()
+                ]
+                combined_condition = and_(*group_conditions)
             stmt = stmt.where(combined_condition)
 
         if self._last_count is not None:

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -320,6 +320,8 @@ def get_filtered_content(
 
     if filters.match_all:
         query = query.match_all()
+    elif filters.match_any:
+        query = query.match_any()
 
     if filters.first is not None:
         query = query.limit(filters.first)

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -99,6 +99,15 @@ class TestSearchCommand:
         assert "mutually exclusive" in result.output
 
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_match_all_and_match_any_together_is_usage_error(self, mock_db_class):
+        mock_db_class.return_value = Mock(session=Mock())
+
+        result = CliRunner().invoke(search_command, ["--match-all", "--match-any"])
+
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.output
+
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_first_rejects_zero(self, mock_db_class):
         mock_db_class.return_value = Mock(session=Mock())
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -140,6 +140,14 @@ class TestNarrowToTrackIds:
 
         assert narrowed.last is None
 
+    def test_clears_match_modes(self):
+        args = SearchRequest(match_any=True)
+
+        narrowed = _narrow_to_track_ids(args, ["a"])
+
+        assert narrowed.match_all is False
+        assert narrowed.match_any is False
+
 
 class TestPrintResponseIds:
     def test_prints_space_separated_ids(self, capsys):

--- a/tests/e2e/test_journey.py
+++ b/tests/e2e/test_journey.py
@@ -88,6 +88,45 @@ def test_search_match_all_combo(cli):
     assert len(matches) == 1
 
 
+def test_search_title_and_format_intersect_by_default(cli):
+    """The original bug report: different filter kinds AND by default now.
+    Title narrows to track 1 ("Wave Alpha"); format narrows to all 3 FLACs.
+    The intersection is just track 1 — no --match-all needed."""
+    matches = _tracks(
+        cli(
+            "search", "--title", WAVE_ALPHA_TITLE, "--format", "flac", "--print", "json"
+        )
+    )
+    assert len(matches) == 1
+
+
+def test_search_default_matches_old_match_all_combo(cli):
+    """Same combo as test_search_match_all_combo, without the flag —
+    different filter kinds (format, artist) AND by default now."""
+    matches = _tracks(
+        cli("search", "--format", "flac", "--artist", "Beta", "--print", "json")
+    )
+    assert len(matches) == 1
+
+
+def test_search_match_any_flattens_across_filter_kinds(cli):
+    """--match-any flattens everything to OR: track 1 (by title) plus both
+    mp3 tracks (by format) — zero overlap, since track 1 is FLAC."""
+    matches = _tracks(
+        cli(
+            "search",
+            "--title",
+            WAVE_ALPHA_TITLE,
+            "--format",
+            "mp3",
+            "--match-any",
+            "--print",
+            "json",
+        )
+    )
+    assert len(matches) == 3
+
+
 def test_search_empty_result_exits_zero(cli):
     result = cli("search", "--title", "DefinitelyNotInLibrary", "--print", "json")
     assert result.returncode == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -73,6 +73,13 @@ class TestFilterArgs:
         with pytest.raises(ValidationError, match="mutually exclusive"):
             FilterArgs(first=2, last=3)
 
+    def test_match_any_defaults_false(self):
+        assert FilterArgs().match_any is False
+
+    def test_match_all_and_match_any_mutually_exclusive(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            FilterArgs(match_all=True, match_any=True)
+
 
 class TestSearchRequest:
     def test_is_filter_args(self):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -729,6 +729,15 @@ class TestGetFilteredContent:
         get_filtered_content(mock_db, FilterArgs(artist=["Daft Punk"]))
         mock_query.match_all.assert_not_called()
 
+    def test_match_any(self, mock_db, mock_query):
+        get_filtered_content(mock_db, FilterArgs(artist=["Daft Punk"], match_any=True))
+        mock_query.match_any.assert_called_once()
+        mock_query.match_all.assert_not_called()
+
+    def test_default_no_match_any(self, mock_db, mock_query):
+        get_filtered_content(mock_db, FilterArgs(artist=["Daft Punk"]))
+        mock_query.match_any.assert_not_called()
+
     def test_track_id_args_combined_with_format(self, mock_db, mock_query):
         """Positional track IDs should combine with other filters, not override them."""
         get_filtered_content(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -28,37 +28,49 @@ class TestCollectionQuery:
         assert str(query._stmt).lower().find("djmdcontent") != -1
 
         # Check initial state
-        assert query._conditions == []
+        assert query._conditions == {}
         assert query._limit_count is None
-        assert query._match_all is False
+        assert query._mode == "grouped"
 
-        # Test with match_all=True
-        query_all = CollectionQuery(match_all=True)
-        assert query_all._match_all is True
+        # Test with an explicit mode
+        query_all = CollectionQuery(mode="all")
+        assert query_all._mode == "all"
 
     def test_match_any(self):
-        """Test that the match_any method correctly sets the _match_all field to False."""
-        query = CollectionQuery(match_all=True)
+        """Test that match_any() sets the flat OR mode."""
+        query = CollectionQuery(mode="all")
 
         new_query = query.match_any()
 
         # Should return a new instance
         assert new_query is not query
-        assert new_query._match_all is False
+        assert new_query._mode == "any"
         # Original should be unchanged
-        assert query._match_all is True
+        assert query._mode == "all"
 
     def test_match_all(self):
-        """Test that the match_all method correctly sets the _match_all field to True."""
-        query = CollectionQuery(match_all=False)
+        """Test that match_all() sets the flat AND mode."""
+        query = CollectionQuery()
 
         new_query = query.match_all()
 
         # Should return a new instance
         assert new_query is not query
-        assert new_query._match_all is True
+        assert new_query._mode == "all"
         # Original should be unchanged
-        assert query._match_all is False
+        assert query._mode == "grouped"
+
+    def test_by_title_and_exact_title_share_a_bucket(self):
+        """Plain and exact variants of the same filter land in the same
+        group, so they OR together under the default grouped mode."""
+        query = CollectionQuery().by_title("A").by_title("B", exact=True)
+        assert len(query._conditions["title"]) == 2
+        assert len(query._conditions) == 1
+
+    def test_different_filter_kinds_use_separate_buckets(self):
+        """Different filter kinds land in separate groups."""
+        query = CollectionQuery().by_title("A").by_format("flac")
+        assert set(query._conditions.keys()) == {"title", "format"}
 
     def test_by_artist(self):
         """Test that the by_artist method outer-joins with the DjmdArtist table and
@@ -72,7 +84,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes a join
         stmt_str = str(new_query._stmt).lower()
@@ -80,7 +92,7 @@ class TestCollectionQuery:
         assert "djmdartist" in stmt_str
 
         # Check that the condition is an ilike operation
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         print(condition_str)
         assert "like lower" in condition_str
         assert '."name"' in condition_str.lower()
@@ -97,7 +109,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes a join
         stmt_str = str(new_query._stmt).lower()
@@ -105,7 +117,7 @@ class TestCollectionQuery:
         assert "djmdartist" in stmt_str
 
         # Check that the condition is an equality operation (not ilike)
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" not in condition_str
         assert "=" in condition_str
 
@@ -122,14 +134,14 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Statement should not have additional joins (only the original select)
         new_stmt_str = str(new_query._stmt)
         assert new_stmt_str == original_stmt_str
 
         # Check that the condition is an ilike operation on Title
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" in condition_str
         assert "title" in condition_str
 
@@ -146,14 +158,14 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Statement should not have additional joins
         new_stmt_str = str(new_query._stmt)
         assert new_stmt_str == original_stmt_str
 
         # Check that the condition is an equality operation (not ilike)
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" not in condition_str
         assert "=" in condition_str
         assert "title" in condition_str
@@ -170,7 +182,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes an outer join
         stmt_str = str(new_query._stmt).lower()
@@ -178,7 +190,7 @@ class TestCollectionQuery:
         assert "djmdalbum" in stmt_str
 
         # Check that the condition is an ilike operation
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" in condition_str
 
     def test_by_exact_album(self):
@@ -193,7 +205,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes an outer join
         stmt_str = str(new_query._stmt).lower()
@@ -201,7 +213,7 @@ class TestCollectionQuery:
         assert "djmdalbum" in stmt_str
 
         # Check that the condition is an equality operation (not ilike)
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" not in condition_str
         assert "=" in condition_str
 
@@ -217,7 +229,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes outer joins with both tables
         stmt_str = str(new_query._stmt).lower()
@@ -226,7 +238,7 @@ class TestCollectionQuery:
         assert "djmdplaylist" in stmt_str
 
         # Check that the condition is an ilike operation
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" in condition_str
 
     def test_by_exact_playlist(self):
@@ -241,7 +253,7 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Check that the statement includes outer joins with both tables
         stmt_str = str(new_query._stmt).lower()
@@ -250,7 +262,7 @@ class TestCollectionQuery:
         assert "djmdplaylist" in stmt_str
 
         # Check that the condition is an equality operation (not ilike)
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "like lower" not in condition_str
         assert "=" in condition_str
 
@@ -272,14 +284,14 @@ class TestCollectionQuery:
         assert new_query is not query
 
         # Check that a condition was added
-        assert len(new_query._conditions) == 1
+        assert len(new_query._flat_conditions) == 1
 
         # Statement should not have additional joins
         new_stmt_str = str(new_query._stmt)
         assert new_stmt_str == original_stmt_str
 
         # Check that the condition is an IN over FileType
-        condition_str = str(new_query._conditions[0]).lower()
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "filetype" in condition_str
         assert "in" in condition_str
 
@@ -291,7 +303,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         query_copy = query._copy()
 
-        assert query_copy._match_all == query._match_all
+        assert query_copy._mode == query._mode
         assert query_copy._conditions == query._conditions
         assert query_copy._limit_count == query._limit_count
         assert str(query_copy._stmt) == str(query._stmt)
@@ -303,7 +315,7 @@ class TestCollectionQuery:
         query.by_album("Discovery").by_format("flac").by_format("aiff").by_title("")
         query_copy = query._copy()
 
-        assert query_copy._match_all == query._match_all
+        assert query_copy._mode == query._mode
         assert query_copy._conditions == query._conditions
         assert query_copy._limit_count == query._limit_count
         assert str(query_copy._stmt) == str(query._stmt)
@@ -315,8 +327,8 @@ class TestCollectionQuery:
         new_query = query.by_track_ids("123")
 
         assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "in" in condition_str
 
     def test_by_track_ids_list(self):
@@ -325,8 +337,8 @@ class TestCollectionQuery:
         new_query = query.by_track_ids(["123", "456", "789"])
 
         assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "in" in condition_str
 
     def test_by_artist_empty_string(self):
@@ -334,8 +346,8 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_artist("")
 
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "null" in condition_str
 
     def test_by_title_empty_string(self):
@@ -343,8 +355,8 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_title("")
 
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "null" in condition_str
 
     def test_by_album_empty_string(self):
@@ -352,8 +364,8 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_album("")
 
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "null" in condition_str
 
     def test_by_playlist_empty_string(self):
@@ -361,8 +373,8 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_playlist("")
 
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0]).lower()
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0]).lower()
         assert "null" in condition_str
 
     def test_by_format_empty_string(self, mocker):
@@ -372,7 +384,7 @@ class TestCollectionQuery:
         result = query.by_format("")
 
         assert result is query
-        assert len(result._conditions) == 0
+        assert len(result._flat_conditions) == 0
         mock_warn.warning.assert_called_once()
 
     def test_by_format_invalid(self, mocker):
@@ -386,7 +398,7 @@ class TestCollectionQuery:
         new_query = query.by_format("xyz")
 
         assert new_query is not query
-        assert len(new_query._conditions) == 0
+        assert len(new_query._flat_conditions) == 0
         mock_warn.warning.assert_called_once()
 
     def test_limit(self):
@@ -455,18 +467,32 @@ class TestCollectionQuery:
             assert stmt_str.index('"folderpath"') < stmt_str.rindex('"id" asc')
 
     def test_get_full_statement_or_logic(self):
-        """Multiple conditions with default OR logic produces OR in the WHERE clause."""
+        """Repeated values of the same filter OR together by default."""
         query = CollectionQuery().by_title("A").by_title("B")
         stmt_str = str(query._get_full_statement()).lower()
         assert " or " in stmt_str
         assert " and " not in stmt_str
 
     def test_get_full_statement_and_logic(self):
-        """Multiple conditions with match_all=True produces AND in the WHERE clause."""
+        """match_all() flattens everything, including repeats, into one AND."""
         query = CollectionQuery().by_title("A").by_title("B").match_all()
         stmt_str = str(query._get_full_statement()).lower()
         assert " and " in stmt_str
         assert " or " not in stmt_str
+
+    def test_get_full_statement_grouped_ands_across_filter_kinds(self):
+        """Default grouped mode ORs same-kind values, then ANDs across kinds."""
+        query = CollectionQuery().by_title("A").by_title("B").by_format("flac")
+        stmt_str = str(query._get_full_statement()).lower()
+        assert " and " in stmt_str
+        assert " or " in stmt_str
+
+    def test_get_full_statement_match_any_flattens_across_kinds(self):
+        """match_any() flattens every condition, ignoring grouping, into one OR."""
+        query = CollectionQuery().by_title("A").by_format("flac").match_any()
+        stmt_str = str(query._get_full_statement()).lower()
+        assert " or " in stmt_str
+        assert " and " not in stmt_str
 
     def test_by_path_substring_against_folderpath_only(self):
         """A --path arg adds a single case-insensitive substring condition on
@@ -475,8 +501,8 @@ class TestCollectionQuery:
         new_query = query.by_path("Daft Punk")
 
         assert new_query is not query
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0])
         assert "FolderPath" in condition_str
         assert "FileNameL" not in condition_str
         assert "LIKE lower" in condition_str
@@ -486,7 +512,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("track.mp3")
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert "%track.mp3%" in condition_str
 
     def test_by_path_preserves_trailing_slash(self):
@@ -495,7 +521,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("Daft Punk/")
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert "%Daft Punk/%" in condition_str
 
     def test_by_path_backslash_normalised_to_forward_slash(self):
@@ -503,7 +529,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("Music\\Artist\\")
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert "\\" not in condition_str
         assert "%Music/Artist/%" in condition_str
 
@@ -512,7 +538,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("../some/relative/track.mp3")
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         # The raw string (or parts of it) must appear, not a resolved absolute path
         assert ".." in condition_str and "relative" in condition_str
 
@@ -521,7 +547,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("")
 
-        assert new_query._conditions == []
+        assert new_query._conditions == {}
 
     # --- by_path resolved mode ---
 
@@ -531,7 +557,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("Album/track.mp3", resolved=True)
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert f"%{cwd}/Album/track.mp3%" in condition_str
 
     def test_by_resolved_path_substring_case_insensitive(self):
@@ -540,8 +566,8 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("/Test/Artist/file.mp3", resolved=True)
 
-        assert len(new_query._conditions) == 1
-        condition_str = str(new_query._conditions[0])
+        assert len(new_query._flat_conditions) == 1
+        condition_str = str(new_query._flat_conditions[0])
         assert "FolderPath" in condition_str
         assert "FileNameL" not in condition_str
         assert "LIKE lower" in condition_str
@@ -554,7 +580,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path(f"{miscased_cwd}/track.mp3", resolved=True)
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert f"{miscased_cwd}/track.mp3" in condition_str
 
     def test_by_resolved_path_preserves_trailing_slash(self):
@@ -563,7 +589,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("Album/", resolved=True)
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert f"{Path(os.getcwd()).as_posix()}/Album/" in condition_str
 
     @pytest.mark.skipif(
@@ -577,7 +603,7 @@ class TestCollectionQuery:
             "C:\\Users\\foo\\music\\Artist\\track.mp3", resolved=True
         )
 
-        condition_str = _compile(new_query._conditions[0])
+        condition_str = _compile(new_query._flat_conditions[0])
         assert "\\" not in condition_str
         assert "C:/Users/foo/music/Artist/track.mp3" in condition_str
 
@@ -586,7 +612,7 @@ class TestCollectionQuery:
         query = CollectionQuery()
         new_query = query.by_path("", resolved=True)
 
-        assert new_query._conditions == []
+        assert new_query._conditions == {}
 
     def test_by_path_returns_new_instance(self):
         """by_path always returns a new CollectionQuery instance."""
@@ -723,8 +749,9 @@ class TestGetFilteredContent:
         mock_query.by_artist.assert_called_once_with("Justice")
         mock_query.match_all.assert_called_once()
 
-    def test_track_id_args_or_with_artist(self, mock_db, mock_query):
-        """Piped IDs OR'd with artist expands the result set."""
+    def test_track_id_args_and_with_artist_by_default(self, mock_db, mock_query):
+        """Piped IDs AND artist filter narrow to their intersection by
+        default, since track ID and artist are different filter kinds."""
         get_filtered_content(mock_db, FilterArgs(track_ids=["123"], artist=["Justice"]))
         mock_query.by_track_ids.assert_called_once_with(track_ids=["123"])
         mock_query.by_artist.assert_called_once_with("Justice")


### PR DESCRIPTION
## Summary
- `CollectionQuery` now buckets conditions by filter kind (title, artist, album, playlist, format, path, track_id). By default, repeated values of the same kind OR together (e.g. `--artist X --artist Y`); different kinds AND together (e.g. `--title X --format Y`).
- Adds `--match-any` as an explicit flat-OR escape hatch, alongside the existing `--match-all` flat-AND.
