### PR TITLE
feat(edit): add FolderPath field with file-existence and length gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
                 - 'ruff.toml'
               paths_ignore:
                 - '**/*.md'
+            docs:
+              paths:
+                - 'docs/**'
+                - 'mkdocs.yml'
+                - '.readthedocs.yaml'
+                # The docsite renders docstrings and CLI help from the package.
+                - 'rekordbox_edit/**'
+                - 'pyproject.toml'
+                - 'uv.lock'
 
   commit-check:
     name: 📝 Commits
@@ -103,6 +112,24 @@ jobs:
       - name: Run e2e tests
         uses: ./.github/actions/e2e
 
+  docs-build:
+    name: 📚 Docs
+    runs-on: ubuntu-latest
+    needs: code-change
+    if: ${{ needs.code-change.outputs.should_skip != 'true' && !fromJSON(needs.code-change.outputs.paths_result || '{}').docs.should_skip }}
+    env:
+      PYTHON: "3.14"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup UV
+        uses: ./.github/actions/install
+
+      # Mirrors the Read the Docs invocation so breaks surface on the PR.
+      - name: Build docs (strict)
+        run: make docs-build
+
   all-green:
     name: ✅ All Green
     if: always()
@@ -111,10 +138,11 @@ jobs:
       - lint
       - unit-tests
       - e2e-tests
+      - docs-build
     runs-on: Ubuntu-latest
 
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: commit-check, unit-tests, lint, e2e-tests
+          allowed-skips: commit-check, unit-tests, lint, e2e-tests, docs-build
           jobs: ${{ toJSON(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ site/
 
 # Superpowers SDD scratch
 .superpowers/
+
+worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         files: pyproject\.toml$
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.4
+    rev: v0.16.5
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -54,6 +54,7 @@ rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
 
 ## Reference
 
+<!-- prettier-ignore -->
 ::: mkdocs-click
     :module: rekordbox_edit.cli.convert
     :command: convert_command

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -6,7 +6,7 @@ Bulk-edit a metadata field on tracks in your Rekordbox database.
 rbe edit [OPTIONS] [TRACK-IDS]... FIELD
 ```
 
-`FIELD` specifies the [DjmdContent](https://pyrekordbox.readthedocs.io/en/latest/formats/db6.html#djmdcontent) column to change. Currently `Title` is the only editable field; more are planned.
+`FIELD` specifies the [DjmdContent](https://pyrekordbox.readthedocs.io/en/latest/formats/db6.html#djmdcontent) column to change. The editable fields are `Title`, `Comment`, `ArtistName`, `AlbumName`, `Rating`, and `FolderPath`.
 
 `--replace` supplies the new value. On its own it overwrites the whole field; add `--match PATTERN` to find that literal text within the field and replace only that portion:
 
@@ -16,6 +16,24 @@ rbe edit --exact-title "Untitled 3" Title --replace "Acid Rain"
 
 # Fix a typo across many titles (substring replacement)
 rbe edit --title "Teh" Title --match "Teh" --replace "The" --multi
+```
+
+## FolderPath
+
+`FolderPath` repoints a track at an audio file on disk. Because the database row carries more than the path, the edit keeps the dependent columns consistent:
+
+- `FileNameL` always follows the new path's file name, and `OrgFolderPath` follows when it matched the old path.
+- When the new file's size differs from the recorded `FileSize`, the file is probed and the technical columns (`FileType`, `SampleRate`, `BitDepth`, `BitRate`, `FileSize`, `Length`) are rewritten to describe it. A byte-identical file, the usual case when relocating a library, needs no probe and no sync.
+- When the file name changes, the `PPTH` path tag inside the track's analysis (ANLZ) files is rewritten to match. Beat grids, cues, and waveforms are indexed by time and are never touched, and the `Analysed` flag is left alone so Rekordbox does not re-analyze.
+
+Two safety checks hold a track back, and both can be overridden. A path whose file does not exist is skipped; overriding writes only the path columns, with nothing to probe. A file whose duration contradicts the track's stored length by more than a second is skipped when the track has cues or an analysis, since those are time-indexed and would land misaligned. In the default flow `edit` lists held-back tracks and asks once whether to include them; in scripted runs (`--yes`) they stay skipped unless you pass `--force`. A file whose format Rekordbox cannot play is always skipped.
+
+```bash
+# Relocate a library folder in bulk
+rbe edit FolderPath --match "/Volumes/OldDrive/Music" --replace "/Volumes/NewDrive/Music" --multi
+
+# Point one track at a replacement file
+rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-rain-remaster.flac"
 ```
 
 ## Guardrails

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -65,8 +65,9 @@ See [Filtering](../filtering.md) for the full filter language.
 
 ## Reference
 
+<!-- prettier-ignore -->
 ::: mkdocs-click
-:module: rekordbox_edit.cli.edit
-:command: edit_command
-:prog_name: rbe edit
-:depth: 1
+    :module: rekordbox_edit.cli.edit
+    :command: edit_command
+    :prog_name: rbe edit
+    :depth: 1

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -22,11 +22,17 @@ rbe edit --title "Teh" Title --match "Teh" --replace "The" --multi
 
 `FolderPath` repoints a track at an audio file on disk. Because the database row carries more than the path, the edit keeps the dependent columns consistent:
 
-- `FileNameL` always follows the new path's file name, and `OrgFolderPath` follows when it matched the old path.
-- When the new file's size differs from the recorded `FileSize`, the file is probed and the technical columns (`FileType`, `SampleRate`, `BitDepth`, `BitRate`, `FileSize`, `Length`) are rewritten to describe it. A byte-identical file, the usual case when relocating a library, needs no probe and no sync.
-- When the file name changes, the `PPTH` path tag inside the track's analysis (ANLZ) files is rewritten to match. Beat grids, cues, and waveforms are indexed by time and are never touched, and the `Analysed` flag is left alone so Rekordbox does not re-analyze.
+- `FileNameL` always matches the new path's file name, and `OrgFolderPath` is updated when it matched the old path.
+- When the new file's size differs from the recorded `FileSize`, the file is probed and all of `FileType`, `SampleRate`, `BitDepth`, `BitRate`, `FileSize`, and `Length` are rewritten to match it.
+- When the file name changes, the `PPTH` path tag inside the track's analysis (ANLZ) files is rewritten to match. All other analysis data is preserved.
 
-Two safety checks hold a track back, and both can be overridden. A path whose file does not exist is skipped; overriding writes only the path columns, with nothing to probe. A file whose duration contradicts the track's stored length by more than a second is skipped when the track has cues or an analysis, since those are time-indexed and would land misaligned. In the default flow `edit` lists held-back tracks and asks once whether to include them; in scripted runs (`--yes`) they stay skipped unless you pass `--force`. A file whose format Rekordbox cannot play is always skipped.
+By default edits will be skipped in the following cases:
+
+- The new path's file does not exist.
+- The new path points to a file whose duration doesn't match what's in rekordbox _and_ the track has cues or an analysis, since those are time-indexed and would land misaligned.
+- The file's format is one Rekordbox doesn't support--always skipped.
+
+`edit` lists the held-back tracks and asks once whether to include them. Providing the `--yes` flag will skip them without prompting whereas `--force` edit them anyway. Including a missing file writes only the path columns.
 
 ```bash
 # Relocate a library folder in bulk
@@ -60,7 +66,7 @@ See [Filtering](../filtering.md) for the full filter language.
 ## Reference
 
 ::: mkdocs-click
-    :module: rekordbox_edit.cli.edit
-    :command: edit_command
-    :prog_name: rbe edit
-    :depth: 1
+:module: rekordbox_edit.cli.edit
+:command: edit_command
+:prog_name: rbe edit
+:depth: 1

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -23,7 +23,7 @@ See [Filtering](../filtering.md) for the full filter language and piping recipes
 ## Reference
 
 ::: mkdocs-click
-:module: rekordbox_edit.cli.search
-:command: search_command
-:prog_name: rbe search
-:depth: 1
+    :module: rekordbox_edit.cli.search
+    :command: search_command
+    :prog_name: rbe search
+    :depth: 1

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -22,6 +22,7 @@ See [Filtering](../filtering.md) for the full filter language and piping recipes
 
 ## Reference
 
+<!-- prettier-ignore -->
 ::: mkdocs-click
     :module: rekordbox_edit.cli.search
     :command: search_command

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -164,6 +164,11 @@ edit_click_options = [
         is_flag=True,
         help="Allow editing more than one track (required when filters match multiple tracks)",
     ),
+    click.option(
+        "--force",
+        is_flag=True,
+        help="Proceed past per-track safety gates that would otherwise skip a track (e.g. a FolderPath target that is missing or whose duration contradicts the track's stored length)",
+    ),
 ]
 
 convert_click_options = [

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -5,6 +5,7 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
 
 from rekordbox_edit.models import ConvertOp, EditOp, Track
+from rekordbox_edit.utils import AudioInfo, get_file_type_for_format
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,31 @@ def _order_tracks_by_op(
     return [
         _track_from_content(content_map[op.id]) for op in ops if op.id in content_map
     ]
+
+
+_MP3_FILE_TYPE = get_file_type_for_format("mp3")
+_FLAC_FILE_TYPE = get_file_type_for_format("flac")
+
+
+def _sync_audio_columns(
+    content: DjmdContent, audio_info: AudioInfo, file_type: int, file_size: int
+) -> None:
+    """Write the technical columns describing an audio file onto its content
+    row: FileType, SampleRate, BitDepth, BitRate, and FileSize. Follows
+    rekordbox's conventions: FLAC bitrate is stored as 0 (VBR) and MP3 bit
+    depth as 16 (probes report none for MP3)."""
+    content.FileType = file_type
+    if audio_info["sample_rate"]:
+        content.SampleRate = audio_info["sample_rate"]
+    if file_type == _MP3_FILE_TYPE:
+        content.BitDepth = 16
+    elif audio_info["bit_depth"]:
+        content.BitDepth = audio_info["bit_depth"]
+    if file_type == _FLAC_FILE_TYPE:
+        content.BitRate = 0
+    elif audio_info["bitrate"] is not None:
+        content.BitRate = audio_info["bitrate"]
+    content.FileSize = file_size
 
 
 def _update_anlz_paths(

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -1,8 +1,12 @@
+import logging
 from collections.abc import Sequence
 
+from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
 
 from rekordbox_edit.models import ConvertOp, EditOp, Track
+
+logger = logging.getLogger(__name__)
 
 _COLUMN_KEYS = tuple(c.key for c in DjmdContent.__table__.columns)
 
@@ -29,3 +33,21 @@ def _order_tracks_by_op(
     return [
         _track_from_content(content_map[op.id]) for op in ops if op.id in content_map
     ]
+
+
+def _update_anlz_paths(
+    db: Rekordbox6Database, content: DjmdContent, new_filename: str
+) -> None:
+    """Rewrite the PPTH path tag in a track's ANLZ files to the given file
+    name, in rekordbox's device-relative ``?/<name>`` form.
+
+    No-op for tracks without an analysis.
+    """
+    if not content.AnalysisDataPath:
+        return
+    new_ppth = f"?/{new_filename}"
+    anlz_files = db.read_anlz_files(content.ID)
+    for anlz_path, anlz in anlz_files.items():
+        anlz.set_path(new_ppth)
+        anlz.save(anlz_path)
+        logger.debug(f"Updated PPTH of {anlz_path} to {new_ppth}")

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -11,7 +11,7 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
 from sqlalchemy import select
 
-from rekordbox_edit.api._utils import _order_tracks_by_op
+from rekordbox_edit.api._utils import _order_tracks_by_op, _update_anlz_paths
 from rekordbox_edit.models import (
     ConvertOp,
     ConvertRequest,
@@ -189,24 +189,6 @@ def _update_database_record(
         content.BitRate = 0
     else:
         content.BitRate = converted_bitrate
-
-
-def _update_anlz_paths(
-    db: Rekordbox6Database, content: DjmdContent, new_filename: str
-) -> None:
-    """Rewrite the PPTH path tag in a track's ANLZ files to the converted file
-    name, in rekordbox's device-relative ``?/<name>`` form.
-
-    No-op for tracks without an analysis.
-    """
-    if not content.AnalysisDataPath:
-        return
-    new_ppth = f"?/{new_filename}"
-    anlz_files = db.read_anlz_files(content.ID)
-    for anlz_path, anlz in anlz_files.items():
-        anlz.set_path(new_ppth)
-        anlz.save(anlz_path)
-        logger.debug(f"Updated PPTH of {anlz_path} to {new_ppth}")
 
 
 def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -11,7 +11,11 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
 from sqlalchemy import select
 
-from rekordbox_edit.api._utils import _order_tracks_by_op, _update_anlz_paths
+from rekordbox_edit.api._utils import (
+    _order_tracks_by_op,
+    _sync_audio_columns,
+    _update_anlz_paths,
+)
 from rekordbox_edit.models import (
     ConvertOp,
     ConvertRequest,
@@ -162,33 +166,19 @@ def _update_database_record(
     if not file_type:
         raise Exception(f"Unsupported output format: {output_format}")
 
-    converted_sample_rate = converted_audio_info["sample_rate"]
-    if converted_sample_rate:
-        content.SampleRate = converted_sample_rate
-
-    if output_format.upper() == "MP3":
-        # Rekordbox records MP3s as 16-bit (see the e2e DB fixtures); probes
-        # report no bit depth for them.
-        content.BitDepth = 16
-    else:
-        converted_bit_depth = converted_audio_info["bit_depth"]
-        if converted_bit_depth:
-            content.BitDepth = converted_bit_depth
-
     content.FileNameL = new_filename
     content.FolderPath = converted_db_path
-    content.FileType = file_type
-    content.FileSize = os.path.getsize(converted_file_path)
 
     # Original location: only update if it matches FolderPath
     if content.OrgFolderPath == old_path:
         content.OrgFolderPath = converted_db_path
 
-    # FLAC stores bitrate as 0 in Rekordbox to represent VBR
-    if output_format.upper() == "FLAC":
-        content.BitRate = 0
-    else:
-        content.BitRate = converted_bitrate
+    _sync_audio_columns(
+        content,
+        {**converted_audio_info, "bitrate": converted_bitrate},
+        file_type,
+        os.path.getsize(converted_file_path),
+    )
 
 
 def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -18,7 +18,9 @@ from rekordbox_edit.query import get_filtered_content
 logger = logging.getLogger(__name__)
 
 
-def _classify_edit(content, args: EditRequest) -> EditOp | SkippedTrack:
+def _classify_edit(
+    db: Rekordbox6Database, content, args: EditRequest
+) -> EditOp | SkippedTrack:
     """Return EditOp if this track should be edited, or SkippedTrack with
     reason if not."""
     handler = FIELD_HANDLERS[args.field]
@@ -30,6 +32,12 @@ def _classify_edit(content, args: EditRequest) -> EditOp | SkippedTrack:
             f"field={args.field} current={current!r}"
         )
         return SkippedTrack(id=str(content.ID), reason="no_change")
+    skip_reason = handler.validate_track(db, content, str(new_value), args)
+    if skip_reason is not None:
+        logger.debug(
+            f"skip edit id={content.ID} reason={skip_reason} field={args.field}"
+        )
+        return SkippedTrack(id=str(content.ID), reason=skip_reason)
     return EditOp(id=str(content.ID), new_value=str(new_value))
 
 
@@ -56,7 +64,7 @@ def edit(
     ops: list[EditOp] = []
     skipped: list[SkippedTrack] = []
     for c in contents:
-        result = _classify_edit(c, args)
+        result = _classify_edit(db, c, args)
         if isinstance(result, EditOp):
             ops.append(result)
         else:
@@ -86,11 +94,17 @@ def edit(
     assert db.session is not None
 
     new_values = {op.id: op.new_value for op in ops}
+    old_values: dict[str, str | None] = {}
     for content in contents:
         if str(content.ID) in new_values:
+            old_values[str(content.ID)] = handler.current_value(content)
             handler.apply(db, content, new_values[str(content.ID)])
     db.session.commit()
     logger.debug(f"edit committed {len(ops)} change(s) on field={args.field}")
+
+    for content in contents:
+        if str(content.ID) in new_values:
+            handler.post_commit(db, content, old_values[str(content.ID)])
 
     return EditResponse(
         tracks=_order_tracks_by_op(contents, ops),

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -7,13 +7,18 @@ own encoding or relational lookup.
 """
 
 import logging
+import os
 
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import tables as tb
 from sqlalchemy import or_
 
-from rekordbox_edit.models import EditRequest
+from rekordbox_edit.api._utils import _sync_audio_columns, _update_anlz_paths
+from rekordbox_edit.models import EditRequest, SkipReason
 from rekordbox_edit.utils import (
+    AudioInfo,
+    get_audio_info,
+    get_file_type_for_probe,
     parse_star_rating,
     star_rating_to_stored,
     stored_to_star_rating,
@@ -31,6 +36,13 @@ class FieldHandler:
     def validate_request(self, args: EditRequest) -> None:
         """Validate request-level input. Raise ValueError on bad input."""
 
+    def validate_track(
+        self, db: Rekordbox6Database, content, new_value: str, args: EditRequest
+    ) -> SkipReason | None:
+        """Per-track validation of a planned edit. Return a skip reason to
+        exclude the track, or None to proceed."""
+        return None
+
     def current_value(self, content) -> str | None:
         raise NotImplementedError  # pragma: no cover
 
@@ -40,6 +52,13 @@ class FieldHandler:
 
     def apply(self, db: Rekordbox6Database, content, new_value: str) -> None:
         raise NotImplementedError  # pragma: no cover
+
+    def post_commit(
+        self, db: Rekordbox6Database, content, old_value: str | None
+    ) -> None:
+        """Called once per edited track after a successful commit, for work
+        that must not run inside the transaction (e.g. file writes). Must not
+        raise."""
 
 
 def _replace(current: str | None, args: EditRequest) -> str | None:
@@ -188,6 +207,114 @@ class RelationalField(FieldHandler):
                     db.delete(row)
 
 
+class FolderPathField(FieldHandler):
+    """The track's audio file path. Repoints the row at a file on disk and
+    keeps the columns describing that file in sync.
+
+    Validation stats the target: a missing file skips the track (or, under
+    force, writes the path without any metadata sync), a byte-identical file
+    needs no probe or sync, and a changed file is probed. A probed duration
+    contradicting the stored Length gates tracks whose cues or analysis are
+    time-indexed, since those would land misaligned; force overrides both
+    gates. A probe no Rekordbox FileType matches always skips."""
+
+    name = "FolderPath"
+    supports_match = True
+
+    _LENGTH_TOLERANCE_SECONDS = 1.0
+
+    def __init__(self):
+        self._probes: dict[tuple[str, str], AudioInfo] = {}
+
+    def current_value(self, content):
+        return content.FolderPath
+
+    def compute_new_value(self, current, args):
+        new_value = _replace(current, args)
+        if new_value is None:
+            return None
+        return new_value.replace("\\", "/")
+
+    def validate_track(self, db, content, new_value, args):
+        if not os.path.exists(new_value):
+            if args.force:
+                logger.warning(
+                    f"{new_value} does not exist; writing the path without "
+                    "syncing audio metadata"
+                )
+                return None
+            return "file_not_found"
+        if os.path.getsize(new_value) == content.FileSize:
+            return None  # byte-identical file: nothing to probe or sync
+        try:
+            probe = get_audio_info(new_value)
+        except Exception:
+            return "unknown_file_type"
+        if get_file_type_for_probe(probe["codec"], probe["container"]) is None:
+            logger.debug(
+                f"skip candidate id={content.ID}: probe of {new_value} "
+                f"(codec={probe['codec']!r}, container={probe['container']!r}) "
+                "matches no Rekordbox file type"
+            )
+            return "unknown_file_type"
+        self._probes[(str(content.ID), new_value)] = probe
+        duration = probe["duration"]
+        if (
+            duration is not None
+            and content.Length is not None
+            and abs(duration - content.Length) > self._LENGTH_TOLERANCE_SECONDS
+        ):
+            mismatch = (
+                f"{new_value} runs {duration:.1f}s but the track's stored "
+                f"length is {content.Length}s"
+            )
+            if args.force:
+                logger.warning(f"{mismatch}; cues and beat grid may be misaligned")
+            elif self._has_time_indexed_analysis(db, content):
+                return "length_mismatch"
+            else:
+                logger.warning(mismatch)
+        return None
+
+    def apply(self, db, content, new_value):
+        old_path = content.FolderPath
+        if content.OrgFolderPath == old_path:
+            content.OrgFolderPath = new_value
+        content.FolderPath = new_value
+        content.FileNameL = new_value.rsplit("/", 1)[-1]
+        if not os.path.exists(new_value):
+            return
+        file_size = os.path.getsize(new_value)
+        if file_size == content.FileSize:
+            return
+        probe = self._probes.get((str(content.ID), new_value))
+        if probe is None:
+            probe = get_audio_info(new_value)
+        file_type = get_file_type_for_probe(probe["codec"], probe["container"])
+        if file_type is None:
+            return  # validate_track skips these; unreachable in the pipeline
+        _sync_audio_columns(content, probe, file_type, file_size)
+        if probe["duration"] is not None:
+            content.Length = int(probe["duration"])
+
+    def post_commit(self, db, content, old_value):
+        old_name = (old_value or "").rsplit("/", 1)[-1]
+        if content.FileNameL == old_name:
+            return  # PPTH stores only ?/<name>; a directory move leaves it valid
+        try:
+            _update_anlz_paths(db, content, content.FileNameL)
+        except Exception as e:
+            logger.warning(
+                f"Failed to update ANLZ path tags for {content.FileNameL}: {e}"
+            )
+
+    def _has_time_indexed_analysis(self, db, content) -> bool:
+        if content.AnalysisDataPath:
+            return True
+        cue = db.session.query(tb.DjmdCue).filter_by(ContentID=content.ID).first()
+        return cue is not None
+
+
 FIELD_HANDLERS: dict[str, FieldHandler] = {
     handler.name: handler
     for handler in (
@@ -196,5 +323,6 @@ FIELD_HANDLERS: dict[str, FieldHandler] = {
         RelationalField("ArtistName", "ArtistID", "ArtistName", "artist"),
         RelationalField("AlbumName", "AlbumID", "AlbumName", "album"),
         RatingField(),
+        FolderPathField(),
     )
 }

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -32,6 +32,9 @@ from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
+# Skip reasons a user can override with --force; other reasons stay skipped.
+_GATED_SKIP_REASONS = frozenset({"file_not_found", "length_mismatch"})
+
 
 @click.command(
     epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
@@ -86,6 +89,24 @@ def edit_command(db, **kwargs):
         preview = edit(db, args, dry_run=True)
     except ValueError as e:
         raise click.UsageError(str(e)) from e
+
+    gated = [s for s in preview.result.skipped if s.reason in _GATED_SKIP_REASONS]
+    if gated and not args.force:
+        logger.info(f"{len(gated)} track(s) were held back by safety checks:")
+        for s in gated:
+            logger.info(f"  {s.id}: {s.reason}")
+        try:
+            if confirm(
+                f"Include {len(gated)} held-back track(s) anyway (--force)?",
+                default=False,
+            ):
+                args = args.model_copy(update={"force": True})
+                try:
+                    preview = edit(db, args, dry_run=True)
+                except ValueError as e:
+                    raise click.UsageError(str(e)) from e
+        except UserQuit:
+            return
 
     if not preview.result.edits:
         logger.info("No changes to make.")

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -79,6 +79,10 @@ class EditRequest(FilterArgs):
     replace_value: str
     match_pattern: str | None = None
     multi: bool = False
+    force: bool = False
+    """Proceed on per-track safety gates that would otherwise skip the track
+    (a FolderPath target that does not exist, or one whose duration contradicts
+    the track's stored length)."""
 
 
 DeleteOriginalsMode: TypeAlias = Literal["none", "lossless", "all"]
@@ -138,6 +142,9 @@ SkipReason: TypeAlias = Literal[
     "unsupported_source_format",
     "output_file_exists",
     "codec_mismatch",
+    "file_not_found",
+    "length_mismatch",
+    "unknown_file_type",
 ]
 
 

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -180,6 +180,7 @@ class AudioInfo(TypedDict):
     bitrate: int | None
     codec: str | None
     container: str | None
+    duration: float | None
 
 
 def get_audio_info(file_path) -> AudioInfo:
@@ -242,6 +243,15 @@ def get_audio_info(file_path) -> AudioInfo:
         if bitrate is None:
             logger.debug(f"Could not determine bitrate for {file_path}")
 
+        duration = None
+        raw_duration = probe.get("format", {}).get("duration") or audio_stream.get(
+            "duration"
+        )
+        if raw_duration is not None:
+            duration = float(raw_duration)
+        else:
+            logger.debug(f"Could not determine duration for {file_path}")
+
         return {
             "bit_depth": bit_depth,
             "sample_rate": int(audio_stream.get("sample_rate", 44100)),
@@ -249,6 +259,7 @@ def get_audio_info(file_path) -> AudioInfo:
             "bitrate": bitrate,
             "codec": audio_stream.get("codec_name"),
             "container": probe.get("format", {}).get("format_name"),
+            "duration": duration,
         }
     except Exception as e:
         logger.error(f"Failed to get audio info for {file_path}: {e}")

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -142,6 +142,16 @@ def probe_matches_file_type(
     return True
 
 
+def get_file_type_for_probe(codec: str | None, container: str | None) -> int | None:
+    """The Rekordbox FileType code for a probed codec/container, or None when
+    no code matches. Only codes with declared codecs are candidates, so the
+    catch-all codes (INVALID, MP4, VIDEO) are never inferred from a probe."""
+    for code, info in FILE_TYPES.items():
+        if info.codecs and probe_matches_file_type(code, codec, container):
+            return code
+    return None
+
+
 class OutputFormats(Enum):
     MP3 = "mp3"
     FLAC = "flac"

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1203,6 +1203,7 @@ class TestClassifyFidelity:
             "bitrate": None,
             "codec": "flac",
             "container": "flac",
+            "duration": None,
         }
 
         assert _classify_fidelity(audio_info) == expected

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -1,7 +1,8 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from rekordbox_edit.api.edit import _classify_edit, edit
+from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -10,50 +11,68 @@ from rekordbox_edit.models import (
 )
 
 
+@pytest.fixture()
+def stub_handler(monkeypatch):
+    """A MagicMock field handler registered as the 'Stub' field."""
+    handler = MagicMock()
+    handler.name = "Stub"
+    handler.current_value.return_value = "Old"
+    handler.compute_new_value.return_value = "New"
+    handler.validate_track.return_value = None
+    monkeypatch.setitem(FIELD_HANDLERS, "Stub", handler)
+    return handler
+
+
 class TestClassifyEdit:
-    def test_returns_edit_op_when_value_would_change(self, make_djmd_content_item):
+    def test_returns_edit_op_when_value_would_change(
+        self, mock_db, make_djmd_content_item
+    ):
         content = make_djmd_content_item(ID="1", Title="Old")
         args = EditRequest(field="Title", replace_value="New")
 
-        result = _classify_edit(content, args)
+        result = _classify_edit(mock_db, content, args)
 
         assert isinstance(result, EditOp)
         assert result.id == "1"
         assert result.new_value == "New"
 
-    def test_returns_skipped_when_value_equals_current(self, make_djmd_content_item):
+    def test_returns_skipped_when_value_equals_current(
+        self, mock_db, make_djmd_content_item
+    ):
         content = make_djmd_content_item(ID="1", Title="Same")
         args = EditRequest(field="Title", replace_value="Same")
 
-        result = _classify_edit(content, args)
+        result = _classify_edit(mock_db, content, args)
 
         assert isinstance(result, SkippedTrack)
         assert result.id == "1"
         assert result.reason == "no_change"
 
-    def test_plain_replace_sets_when_current_is_none(self, make_djmd_content_item):
+    def test_plain_replace_sets_when_current_is_none(
+        self, mock_db, make_djmd_content_item
+    ):
         content = make_djmd_content_item(ID="1", Title=None)
         args = EditRequest(field="Title", replace_value="New")
 
-        result = _classify_edit(content, args)
+        result = _classify_edit(mock_db, content, args)
 
         assert isinstance(result, EditOp)
         assert result.new_value == "New"
 
-    def test_match_skips_when_current_is_none(self, make_djmd_content_item):
+    def test_match_skips_when_current_is_none(self, mock_db, make_djmd_content_item):
         content = make_djmd_content_item(ID="1", Title=None)
         args = EditRequest(field="Title", replace_value="b", match_pattern="a")
 
-        result = _classify_edit(content, args)
+        result = _classify_edit(mock_db, content, args)
 
         assert isinstance(result, SkippedTrack)
         assert result.reason == "no_change"
 
-    def test_match_pattern_applied(self, make_djmd_content_item):
+    def test_match_pattern_applied(self, mock_db, make_djmd_content_item):
         content = make_djmd_content_item(ID="1", Title="Hello World")
         args = EditRequest(field="Title", replace_value="Earth", match_pattern="World")
 
-        result = _classify_edit(content, args)
+        result = _classify_edit(mock_db, content, args)
 
         assert isinstance(result, EditOp)
         assert result.new_value == "Hello Earth"
@@ -204,3 +223,59 @@ class TestEditRealRun:
         mock_gfc.return_value.scalars.return_value.all.return_value = []
         with pytest.raises(ValueError, match="Unknown field"):
             edit(mock_db, EditRequest(field="Nope", replace_value="x"))
+
+
+class TestValidateTrackHook:
+    def test_skip_reason_from_handler(
+        self, mock_db, make_djmd_content_item, stub_handler
+    ):
+        stub_handler.validate_track.return_value = "file_not_found"
+        content = make_djmd_content_item(ID="1")
+        args = EditRequest(field="Stub", replace_value="New")
+
+        result = _classify_edit(mock_db, content, args)
+
+        assert isinstance(result, SkippedTrack)
+        assert result.reason == "file_not_found"
+        stub_handler.validate_track.assert_called_once_with(
+            mock_db, content, "New", args
+        )
+
+    def test_none_proceeds(self, mock_db, make_djmd_content_item, stub_handler):
+        content = make_djmd_content_item(ID="1")
+
+        result = _classify_edit(
+            mock_db, content, EditRequest(field="Stub", replace_value="New")
+        )
+
+        assert isinstance(result, EditOp)
+
+
+class TestPostCommitHook:
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_called_after_commit_with_old_value(
+        self, mock_gfc, mock_db, make_djmd_content_item, stub_handler
+    ):
+        content = make_djmd_content_item(ID="1")
+        mock_gfc.return_value.scalars.return_value.all.return_value = [content]
+        order = MagicMock()
+        order.attach_mock(mock_db.session.commit, "commit")
+        order.attach_mock(stub_handler.post_commit, "post_commit")
+
+        edit(mock_db, EditRequest(field="Stub", replace_value="New"))
+
+        stub_handler.post_commit.assert_called_once_with(mock_db, content, "Old")
+        assert order.mock_calls.index(call.commit()) < order.mock_calls.index(
+            call.post_commit(mock_db, content, "Old")
+        )
+
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_not_called_on_dry_run(
+        self, mock_gfc, mock_db, make_djmd_content_item, stub_handler
+    ):
+        content = make_djmd_content_item(ID="1")
+        mock_gfc.return_value.scalars.return_value.all.return_value = [content]
+
+        edit(mock_db, EditRequest(field="Stub", replace_value="New"), dry_run=True)
+
+        stub_handler.post_commit.assert_not_called()

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -311,12 +311,23 @@ class TestFolderPathField:
         assert isinstance(handler, FolderPathField)
         assert handler.supports_match is True
 
+    def test_current_value_reads_folder_path(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1", FolderPath="/old/song.wav")
+        assert _folder_handler().current_value(content) == "/old/song.wav"
+
     def test_compute_normalizes_backslashes(self):
         args = EditRequest(field="FolderPath", replace_value=r"C:\Music\song.wav")
         assert (
             _folder_handler().compute_new_value("/old/song.wav", args)
             == "C:/Music/song.wav"
         )
+
+    def test_compute_match_skips_none(self):
+        # --match has no text to search when the field is empty.
+        args = EditRequest(
+            field="FolderPath", replace_value="/new/song.wav", match_pattern="/old"
+        )
+        assert _folder_handler().compute_new_value(None, args) is None
 
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
     def test_validate_missing_file_skips(self, _exists, make_djmd_content_item):
@@ -360,6 +371,25 @@ class TestFolderPathField:
 
         assert reason is None
         mock_probe.assert_not_called()
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        side_effect=OSError("ffprobe failed"),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_probe_failure_skips(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason == "unknown_file_type"
 
     @patch(
         "rekordbox_edit.api.field_handlers.get_audio_info",
@@ -538,6 +568,57 @@ class TestFolderPathField:
         assert content.BitRate == 0  # FLAC stores VBR as 0
         assert content.FileSize == 2000
         assert content.Length == 214
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(
+            codec="mp3", container="mp3", bit_depth=None, bitrate=None, duration=None
+        ),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_apply_probes_on_cache_miss_and_keeps_unreported_columns(
+        self, _exists, _getsize, mock_probe, make_djmd_content_item
+    ):
+        # apply without a prior validate_track probes the file itself; columns
+        # the probe reports as None keep their stored values.
+        handler = _folder_handler()
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/old/dir/song.wav", FileNameL="song.wav", FileType=11
+        )
+        content.FileSize = 1000
+        content.Length = 214
+        content.BitRate = 320
+
+        handler.apply(MagicMock(), content, "/new/dir/song.mp3")
+
+        mock_probe.assert_called_once_with("/new/dir/song.mp3")
+        assert content.FileType == 1
+        assert content.FileSize == 2000
+        assert content.BitDepth == 16  # rekordbox stores MP3 bit depth as 16
+        assert content.BitRate == 320
+        assert content.Length == 214
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(codec="vorbis", container="ogg"),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_apply_unknown_file_type_leaves_audio_columns(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        handler = _folder_handler()
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/old/dir/song.wav", FileNameL="song.wav", FileType=11
+        )
+        content.FileSize = 1000
+
+        handler.apply(MagicMock(), content, "/new/dir/song.ogg")
+
+        assert content.FolderPath == "/new/dir/song.ogg"
+        assert content.FileType == 11
+        assert content.FileSize == 1000
 
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
     def test_apply_forced_missing_file_writes_paths_only(

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rekordbox_edit.api.field_handlers import (
     FIELD_HANDLERS,
+    FolderPathField,
     RelationalField,
     StringField,
 )
@@ -280,3 +281,317 @@ class TestRelationalAlbum:
         _album_handler().apply(db, content, "New Name")
 
         db.delete.assert_not_called()
+
+
+def _folder_handler():
+    return FolderPathField()
+
+
+def _probe(**overrides):
+    info = {
+        "bit_depth": 16,
+        "sample_rate": 44100,
+        "channels": 2,
+        "bitrate": 1411,
+        "codec": "pcm_s16le",
+        "container": "wav",
+        "duration": 214.4,
+    }
+    info.update(overrides)
+    return info
+
+
+def _no_cues(db):
+    db.session.query.return_value.filter_by.return_value.first.return_value = None
+
+
+class TestFolderPathField:
+    def test_registered(self):
+        handler = FIELD_HANDLERS["FolderPath"]
+        assert isinstance(handler, FolderPathField)
+        assert handler.supports_match is True
+
+    def test_compute_normalizes_backslashes(self):
+        args = EditRequest(field="FolderPath", replace_value=r"C:\Music\song.wav")
+        assert (
+            _folder_handler().compute_new_value("/old/song.wav", args)
+            == "C:/Music/song.wav"
+        )
+
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
+    def test_validate_missing_file_skips(self, _exists, make_djmd_content_item):
+        content = make_djmd_content_item(ID="1")
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason == "file_not_found"
+
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
+    def test_validate_missing_file_forced_proceeds(
+        self, _exists, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        args = EditRequest(
+            field="FolderPath", replace_value="/new/song.wav", force=True
+        )
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason is None
+
+    @patch("rekordbox_edit.api.field_handlers.get_audio_info")
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=1000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_same_size_skips_probe(
+        self, _exists, _getsize, mock_probe, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1", FileSize=1000)
+        content.FileSize = 1000
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason is None
+        mock_probe.assert_not_called()
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(codec="vorbis", container="ogg"),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_unknown_codec_skips_even_forced(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        args = EditRequest(
+            field="FolderPath", replace_value="/new/song.ogg", force=True
+        )
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.ogg", args
+        )
+
+        assert reason == "unknown_file_type"
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(duration=300.0),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_length_mismatch_with_analysis_skips(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        content.Length = 214
+        content.AnalysisDataPath = "/PIONEER/USBANLZ/x/ANLZ0000.DAT"
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason == "length_mismatch"
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(duration=300.0),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_length_mismatch_with_cues_skips(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        content.Length = 214
+        content.AnalysisDataPath = None
+        db = MagicMock()
+        db.session.query.return_value.filter_by.return_value.first.return_value = (
+            MagicMock()  # a cue row exists
+        )
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(db, content, "/new/song.wav", args)
+
+        assert reason == "length_mismatch"
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(duration=300.0),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_length_mismatch_without_analysis_warns_only(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        content.Length = 214
+        content.AnalysisDataPath = None
+        db = MagicMock()
+        _no_cues(db)
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        reason = _folder_handler().validate_track(db, content, "/new/song.wav", args)
+
+        assert reason is None
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(duration=300.0),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_length_mismatch_forced_proceeds(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        content.Length = 214
+        content.AnalysisDataPath = "/PIONEER/USBANLZ/x/ANLZ0000.DAT"
+        args = EditRequest(
+            field="FolderPath", replace_value="/new/song.wav", force=True
+        )
+
+        reason = _folder_handler().validate_track(
+            MagicMock(), content, "/new/song.wav", args
+        )
+
+        assert reason is None
+
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=1000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_apply_relocation_updates_paths_only(
+        self, _exists, _getsize, make_djmd_content_item
+    ):
+        handler = _folder_handler()
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/old/dir/song.wav", FileNameL="song.wav"
+        )
+        content.FileSize = 1000
+        content.OrgFolderPath = "/old/dir/song.wav"
+        content.SampleRate = 44100
+        content.BitDepth = 16
+        content.BitRate = 1411
+        content.FileType = 11
+        db = MagicMock()
+        args = EditRequest(field="FolderPath", replace_value="/new/dir/song.wav")
+        assert handler.validate_track(db, content, "/new/dir/song.wav", args) is None
+
+        handler.apply(db, content, "/new/dir/song.wav")
+
+        assert content.FolderPath == "/new/dir/song.wav"
+        assert content.FileNameL == "song.wav"
+        assert content.OrgFolderPath == "/new/dir/song.wav"
+        # Same bytes: technical columns stay as they were.
+        assert content.SampleRate == 44100
+        assert content.FileSize == 1000
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        return_value=_probe(
+            codec="flac",
+            container="flac",
+            bit_depth=24,
+            sample_rate=48000,
+            bitrate=2304,
+            duration=214.9,
+        ),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_apply_replaced_file_syncs_metadata(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        handler = _folder_handler()
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/old/dir/song.wav", FileNameL="song.wav", FileType=11
+        )
+        content.FileSize = 1000
+        content.Length = 214
+        content.OrgFolderPath = "/elsewhere/song.wav"
+        db = MagicMock()
+        _no_cues(db)
+        args = EditRequest(field="FolderPath", replace_value="/new/dir/song.flac")
+        assert handler.validate_track(db, content, "/new/dir/song.flac", args) is None
+
+        handler.apply(db, content, "/new/dir/song.flac")
+
+        assert content.FolderPath == "/new/dir/song.flac"
+        assert content.FileNameL == "song.flac"
+        # OrgFolderPath did not match the old path, so it stays put.
+        assert content.OrgFolderPath == "/elsewhere/song.wav"
+        assert content.FileType == 5
+        assert content.SampleRate == 48000
+        assert content.BitDepth == 24
+        assert content.BitRate == 0  # FLAC stores VBR as 0
+        assert content.FileSize == 2000
+        assert content.Length == 214
+
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
+    def test_apply_forced_missing_file_writes_paths_only(
+        self, _exists, make_djmd_content_item
+    ):
+        handler = _folder_handler()
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/old/dir/song.wav", FileNameL="song.wav", FileType=11
+        )
+        content.FileSize = 1000
+        db = MagicMock()
+        args = EditRequest(
+            field="FolderPath", replace_value="/gone/dir/song.wav", force=True
+        )
+        assert handler.validate_track(db, content, "/gone/dir/song.wav", args) is None
+
+        handler.apply(db, content, "/gone/dir/song.wav")
+
+        assert content.FolderPath == "/gone/dir/song.wav"
+        assert content.FileNameL == "song.wav"
+        assert content.FileSize == 1000
+        assert content.FileType == 11
+
+    @patch("rekordbox_edit.api.field_handlers._update_anlz_paths")
+    def test_post_commit_rewrites_ppth_on_rename(
+        self, mock_anlz, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/new/dir/song.flac", FileNameL="song.flac"
+        )
+        db = MagicMock()
+
+        _folder_handler().post_commit(db, content, "/old/dir/song.wav")
+
+        mock_anlz.assert_called_once_with(db, content, "song.flac")
+
+    @patch("rekordbox_edit.api.field_handlers._update_anlz_paths")
+    def test_post_commit_skips_when_basename_unchanged(
+        self, mock_anlz, make_djmd_content_item
+    ):
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/new/dir/song.wav", FileNameL="song.wav"
+        )
+
+        _folder_handler().post_commit(MagicMock(), content, "/old/dir/song.wav")
+
+        mock_anlz.assert_not_called()
+
+    @patch("rekordbox_edit.api.field_handlers._update_anlz_paths")
+    def test_post_commit_swallows_anlz_errors(self, mock_anlz, make_djmd_content_item):
+        mock_anlz.side_effect = OSError("disk full")
+        content = make_djmd_content_item(
+            ID="1", FolderPath="/new/dir/song.flac", FileNameL="song.flac"
+        )
+
+        # Must not raise: the row commit already succeeded.
+        _folder_handler().post_commit(MagicMock(), content, "/old/dir/song.wav")

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from rekordbox_edit.cli.edit import edit_command
-from rekordbox_edit.models import EditOp, EditResponse, EditResult, Track
+from rekordbox_edit.models import EditOp, EditResponse, EditResult, SkippedTrack, Track
 from rekordbox_edit.utils import UserQuit
 
 
@@ -237,3 +237,117 @@ class TestEditCommand:
 
         assert result.exit_code == 0
         mock_edit.assert_called_once()  # preview only — UserQuit on first track
+
+
+def _gated_response(tracks=None, edits=None):
+    tracks = (
+        tracks
+        if tracks is not None
+        else [Track(ID="1", Title="T", FileNameL="x.wav", FolderPath="/x.wav")]
+    )
+    edits = (
+        edits
+        if edits is not None
+        else [EditOp(id=t.ID, new_value="/new/x.wav") for t in tracks]
+    )
+    return EditResponse(
+        tracks=tracks,
+        result=EditResult(
+            field="FolderPath",
+            edits=edits,
+            skipped=[SkippedTrack(id="9", reason="file_not_found")],
+        ),
+    )
+
+
+class TestEditForceFlow:
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_force_flag_passes_through(self, mock_db_class, mock_edit):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response()
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes", "--force"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_edit.call_args.args[1].force is True
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_default_flow_includes_gated_on_confirm(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response()
+        # Include the gated track, then apply.
+        mock_confirm.side_effect = [True, True]
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
+        )
+
+        assert result.exit_code == 0
+        # preview, forced re-preview, real run
+        assert mock_edit.call_count == 3
+        assert mock_edit.call_args_list[0].args[1].force is False
+        assert mock_edit.call_args_list[1].args[1].force is True
+        assert mock_edit.call_args_list[1].kwargs.get("dry_run") is True
+        assert mock_edit.call_args_list[2].args[1].force is True
+        assert mock_edit.call_args_list[2].kwargs.get("dry_run", False) is False
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_default_flow_gated_declined_stays_unforced(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response()
+        # Leave the gated track skipped, then apply the rest.
+        mock_confirm.side_effect = [False, True]
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_edit.call_count == 2  # preview + real run
+        assert mock_edit.call_args_list[1].args[1].force is False
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_default_flow_no_gated_prompt_when_forced(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response()
+        mock_confirm.side_effect = [True]  # only the apply prompt
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav", "--force"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_edit.call_count == 2
+        assert mock_confirm.call_count == 1
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_yes_mode_leaves_gated_skipped(self, mock_db_class, mock_edit):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response()
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav", "--yes"]
+        )
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()
+        assert mock_edit.call_args.args[1].force is False

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -23,10 +23,10 @@ def mock_rekordbox_not_running():
 
 
 def _response(tracks=None, edits=None, skipped=None):
-    tracks = tracks or [
-        Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")
-    ]
-    edits = edits or [EditOp(id=t.ID, new_value="New") for t in tracks]
+    if tracks is None:
+        tracks = [Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")]
+    if edits is None:
+        edits = [EditOp(id=t.ID, new_value="New") for t in tracks]
     return EditResponse(
         tracks=tracks,
         result=EditResult(field="Title", edits=edits, skipped=skipped or []),
@@ -84,6 +84,19 @@ class TestEditCommand:
         result = CliRunner().invoke(
             edit_command, ["Title", "--replace", "New", "--yes"]
         )
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_default_flow_value_error_becomes_usage_error(
+        self, mock_db_class, mock_edit
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = ValueError("Found 2 tracks that would be edited")
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
 
         assert result.exit_code != 0
         assert "Error" in result.output
@@ -337,6 +350,46 @@ class TestEditForceFlow:
         assert result.exit_code == 0
         assert mock_edit.call_count == 2
         assert mock_confirm.call_count == 1
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_gated_prompt_user_quit_skips_commit(
+        self, mock_db_class, mock_edit, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response()
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
+        )
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_including_gated_tracks_can_trip_multi_guard(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        # Including the held-back track widens the edit past one track, which
+        # the single-track guard rejects on the re-preview.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = [
+            _gated_response(),
+            ValueError("Found 2 tracks that would be edited"),
+        ]
+        mock_confirm.side_effect = [True]
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
+        )
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
 
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")

--- a/tests/e2e/test_edit_fields.py
+++ b/tests/e2e/test_edit_fields.py
@@ -126,3 +126,82 @@ def test_rating_written_as_stored_value(fresh_db):
     moved = db.session.query(tb.DjmdContent).filter_by(Title="Apple Alpha").one()
     assert moved.Rating == 204
     db.close()
+
+
+def test_folderpath_relocation_updates_paths_only(fresh_db, staged_audio, tmp_path):
+    new_dir = tmp_path / "moved"
+    new_dir.mkdir()
+    shutil.copy(staged_audio / "01-flac-44_1k-16b.flac", new_dir)
+
+    db = Rekordbox6Database(fresh_db)
+    assert db.session is not None
+    before = db.session.query(tb.DjmdContent).filter_by(Title="Wave Alpha").one()
+    old_size, old_type, old_rate = before.FileSize, before.FileType, before.SampleRate
+
+    edit(
+        db,
+        EditRequest(
+            exact_title=["Wave Alpha"],
+            field="FolderPath",
+            match_pattern=staged_audio.as_posix(),
+            replace_value=new_dir.as_posix(),
+        ),
+    )
+
+    moved = db.session.query(tb.DjmdContent).filter_by(Title="Wave Alpha").one()
+    assert moved.FolderPath == f"{new_dir.as_posix()}/01-flac-44_1k-16b.flac"
+    assert moved.FileNameL == "01-flac-44_1k-16b.flac"
+    # Byte-identical file: the technical columns stay as they were.
+    assert moved.FileSize == old_size
+    assert moved.FileType == old_type
+    assert moved.SampleRate == old_rate
+    db.close()
+
+
+def test_folderpath_repoint_syncs_metadata(fresh_db, staged_audio):
+    target = staged_audio / "05-aiff-44_1k-16b.aiff"
+
+    db = Rekordbox6Database(fresh_db)
+    assert db.session is not None
+
+    # Repoint the FLAC track "Wave Alpha" at a staged AIFF file.
+    edit(
+        db,
+        EditRequest(
+            exact_title=["Wave Alpha"],
+            field="FolderPath",
+            replace_value=target.as_posix(),
+            force=True,
+        ),
+    )
+
+    moved = db.session.query(tb.DjmdContent).filter_by(Title="Wave Alpha").one()
+    assert moved.FolderPath == target.as_posix()
+    assert moved.FileNameL == "05-aiff-44_1k-16b.aiff"
+    assert moved.FileType == 12  # AIFF
+    assert moved.FileSize == target.stat().st_size
+    assert moved.SampleRate == 44100
+    assert moved.BitDepth == 16
+    db.close()
+
+
+def test_folderpath_missing_file_skips_track(fresh_db):
+    db = Rekordbox6Database(fresh_db)
+    assert db.session is not None
+    before = db.session.query(tb.DjmdContent).filter_by(Title="Wave Alpha").one()
+    old_path = before.FolderPath
+
+    response = edit(
+        db,
+        EditRequest(
+            exact_title=["Wave Alpha"],
+            field="FolderPath",
+            replace_value="/nowhere/does-not-exist.flac",
+        ),
+    )
+
+    assert [s.reason for s in response.result.skipped] == ["file_not_found"]
+    assert response.result.edits == []
+    unchanged = db.session.query(tb.DjmdContent).filter_by(Title="Wave Alpha").one()
+    assert unchanged.FolderPath == old_path
+    db.close()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -96,6 +96,7 @@ class TestEditRequest:
         assert args.replace_value == "New"
         assert args.artist == ["X"]
         assert args.multi is False
+        assert args.force is False
 
 
 class TestConvertRequest:
@@ -118,6 +119,14 @@ class TestSkippedTrack:
         assert (
             SkippedTrack(id="1", reason="output_file_exists").reason
             == "output_file_exists"
+        )
+        assert SkippedTrack(id="1", reason="file_not_found").reason == "file_not_found"
+        assert (
+            SkippedTrack(id="1", reason="length_mismatch").reason == "length_mismatch"
+        )
+        assert (
+            SkippedTrack(id="1", reason="unknown_file_type").reason
+            == "unknown_file_type"
         )
 
     def test_unknown_reason_rejected(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from rekordbox_edit.utils import (
     get_file_type_for_format,
     get_file_type_name,
     parse_star_rating,
+    get_file_type_for_probe,
     probe_matches_file_type,
     star_rating_to_stored,
     stored_to_star_rating,
@@ -549,6 +550,24 @@ class TestProbeMatchesFileType:
     )
     def test_matching(self, code, codec, container, expected):
         assert probe_matches_file_type(code, codec, container) is expected
+
+
+class TestGetFileTypeForProbe:
+    @pytest.mark.parametrize(
+        "codec,container,expected",
+        [
+            ("flac", "flac", 5),
+            ("alac", "mov,mp4,m4a,3gp,3g2,mj2", 6),
+            ("aac", "mov,mp4,m4a,3gp,3g2,mj2", 4),
+            ("pcm_s16le", "wav", 11),
+            ("pcm_s16be", "aiff", 12),
+            ("mp3", "mp3", 1),
+            ("vorbis", "ogg", None),  # no Rekordbox FileType for this codec
+            (None, None, None),
+        ],
+    )
+    def test_mapping(self, codec, container, expected):
+        assert get_file_type_for_probe(codec, container) == expected
 
 
 @pytest.mark.parametrize("stars,stored", [(0, 0), (1, 51), (3, 153), (5, 255)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,6 +225,64 @@ class TestGetAudioInfo:
         assert result["bitrate"] == 1411
 
     @patch("rekordbox_edit.utils.ffmpeg.probe")
+    def test_get_audio_info__duration_from_format(self, mock_probe, ffmpeg_exists):
+        """Duration comes from the probe's format section."""
+        mock_probe.return_value = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "bits_per_sample": 16,
+                    "sample_rate": "44100",
+                    "channels": 2,
+                }
+            ],
+            "format": {"format_name": "wav", "duration": "214.398"},
+        }
+
+        result = get_audio_info("/path/to/audio.wav")
+
+        assert result["duration"] == pytest.approx(214.398)
+
+    @patch("rekordbox_edit.utils.ffmpeg.probe")
+    def test_get_audio_info__duration_falls_back_to_stream(
+        self, mock_probe, ffmpeg_exists
+    ):
+        """Stream duration is used when the format section has none."""
+        mock_probe.return_value = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "bits_per_sample": 16,
+                    "sample_rate": "44100",
+                    "channels": 2,
+                    "duration": "183.02",
+                }
+            ],
+            "format": {"format_name": "flac"},
+        }
+
+        result = get_audio_info("/path/to/audio.flac")
+
+        assert result["duration"] == pytest.approx(183.02)
+
+    @patch("rekordbox_edit.utils.ffmpeg.probe")
+    def test_get_audio_info__duration_missing_is_none(self, mock_probe, ffmpeg_exists):
+        mock_probe.return_value = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "bits_per_sample": 16,
+                    "sample_rate": "44100",
+                    "channels": 2,
+                }
+            ]
+        }
+
+        result = get_audio_info("/path/to/audio.wav")
+
+        assert result["duration"] is None
+
+    @patch("rekordbox_edit.utils.ffmpeg.probe")
     def test_get_audio_info__no_audio_stream(self, mock_probe, ffmpeg_exists):
         """Test exception is raised when no audio stream exists."""
         # Setup mock probe response without audio stream


### PR DESCRIPTION
Adds `FolderPath` as an editable field, completing the core column set for `edit`.
Closes #25 

  - `feat(utils): report duration in audio probe` — `get_audio_info` now returns duration.
  - `refactor(api): share ANLZ path rewrite and add probe-to-FileType lookup` — moves convert's PPTH rewrite into `api/_utils.py`, adds `get_file_type_for_probe`.
  - `feat(edit): add FolderPath field with file-existence and length gates` — the handler. Same-size targets update path columns only; changed files get
  probed and `FileType`/`SampleRate`/`BitDepth`/`BitRate`/`FileSize`/`Length` synced. `FileNameL` and `OrgFolderPath` follow, PPTH rewritten on rename, `Analysed` untouched. Skips on missing files and on duration/Length mismatch when the track has cues or analysis; new `validate_track`/`post_commit` hooks on `FieldHandler`.
  - `refactor(convert): reuse shared audio-column sync` — convert now writes those columns through the same helper.
  - `feat(cli): add --force and a held-back-track prompt to edit` — `--force` overrides the gates; the default flow lists held-back tracks and asks once.
  - `test(e2e): cover FolderPath relocation, repoint, and missing-file skip` — plus docs for the field.
  - `ci: validate the docs build` — fixes the mkdocs-click indentation in `search.md` and adds a strict docs build job to CI.

  Covered by unit tests and new e2e cases