### PR TITLE
feat(cli): serialize write commands behind a single-writer lock

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -57,3 +57,25 @@ Ultimately, if you're planning on doing an in-place conversion of tracks in your
 - **Sync back cues, grids, and info from your USBs** Converting a track that has been exported will orphan the exported version and any un-synced metadata from your library.
 - **Keep your originals until you are satisfied.** The default `--delete-originals lossless` only deletes a source when no audio information was lost. Be deliberate before choosing `all`.
 - **Lock hand-tuned beat grids if you plan to re-analyze.** Conversion won't mess with your grids, but a later bulk re-analysis replaces grids on unlocked tracks. Analysis Lock exists for exactly this.
+
+## Can I run two rekordbox-edit commands at once?
+
+No. Commands that write to the database take a single-writer lock for the
+whole run, so a second `edit`, `convert`, or `import` against the same library
+refuses to start and names the process already holding it:
+
+```
+Another rekordbox-edit process is writing to this library (PID 41207, "convert", started 14:02:31). Wait for it to finish, then try again.
+```
+
+Two commands writing at the same time can interleave: one decides what it is
+going to change, the other changes those same tracks underneath it, and the
+first proceeds on a stale plan.
+
+Reads are unaffected. `search` never takes the lock, and neither does any
+write command run with `--dry-run`, so you can plan one operation while
+another is still running.
+
+A run started with `--yes` waits up to five seconds for the lock before
+giving up, which lets back-to-back scripted runs sort themselves out.
+Interactive runs fail immediately rather than leaving you at a hung prompt.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -60,22 +60,10 @@ Ultimately, if you're planning on doing an in-place conversion of tracks in your
 
 ## Can I run two rekordbox-edit commands at once?
 
-No. Commands that write to the database take a single-writer lock for the
-whole run, so a second `edit`, `convert`, or `import` against the same library
-refuses to start and names the process already holding it:
+Yes, but any command that writes to the database holds a lock for its whole
+run, and a concurrent `rbe` will wait up to 30 seconds for that lock before
+giving up. An interactive invocation never waits: it exits immediately if
+another invocation holds the lock.
 
-```
-Another rekordbox-edit process is writing to this library (PID 41207, "convert", started 14:02:31). Wait for it to finish, then try again.
-```
-
-Two commands writing at the same time can interleave: one decides what it is
-going to change, the other changes those same tracks underneath it, and the
-first proceeds on a stale plan.
-
-Reads are unaffected. `search` never takes the lock, and neither does any
-write command run with `--dry-run`, so you can plan one operation while
-another is still running.
-
-A run started with `--yes` waits up to five seconds for the lock before
-giving up, which lets back-to-back scripted runs sort themselves out.
-Interactive runs fail immediately rather than leaving you at a hung prompt.
+Reads are unaffected. `search` never takes the lock, and neither does a write
+command run with `--dry-run`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "rich>=15.0.0,<15.1.0",
     "pydantic>=2.0,<3",
     "mutagen>=1.48.1",
+    "filelock>=3.13,<4",
 ]
 
 [dependency-groups]

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,5 +1,6 @@
 """CLI-private helpers: stdin handling, scripting guards, args narrowing, print emitters."""
 
+import contextlib
 import functools
 import logging
 import sys
@@ -10,13 +11,20 @@ import click
 from pydantic import BaseModel, ValidationError
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.utils import get_rekordbox_pid
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 from rekordbox_edit._click import PrintChoice, database_path_option
+from rekordbox_edit.locking import SCRIPTED_TIMEOUT, DatabaseBusyError, database_lock
 from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
 SCRIPTING_MODES = (PrintChoice.IDS, PrintChoice.SILENT, PrintChoice.JSON)
+
+#: How long SQLite retries when another connection (typically Rekordbox
+#: itself) holds the write lock, before raising OperationalError.
+BUSY_TIMEOUT_MS = 5000
 
 _ArgsT = TypeVar("_ArgsT", bound=BaseModel)
 
@@ -116,11 +124,44 @@ def _rekordbox_running_confirm(print_opt) -> bool:
         return False
 
 
+@event.listens_for(Engine, "connect")
+def _set_busy_timeout(dbapi_connection, _record) -> None:
+    """Make SQLite wait instead of failing immediately on a contended write lock.
+
+    Bound to the Engine class rather than an instance because pyrekordbox
+    builds the engine itself and connects lazily on the first query, leaving
+    no point at which to attach a per-engine listener.
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+    finally:
+        cursor.close()
+
+
+def _write_lock(db, kwargs):
+    """Return the advisory lock context for a write command.
+
+    Dry runs never write, so they stay usable while another command holds the
+    lock. Interactive runs fail immediately rather than hanging on a prompt
+    the user cannot see; --yes runs are scripted and can afford to wait.
+    """
+    if kwargs.get("dry_run"):
+        return contextlib.nullcontext()
+    ctx = click.get_current_context(silent=True)
+    return database_lock(
+        db.db_directory,
+        command=(ctx.info_name if ctx else None) or "rbe",
+        timeout=SCRIPTED_TIMEOUT if kwargs.get("yes") else 0,
+    )
+
+
 def with_database(*, writes: bool = False):
     """Inject an opened Rekordbox6Database as `db` and close it on exit.
 
     Pass writes=True for commands that modify the DB: the wrapper aborts when
-    Rekordbox is running (or prompts to continue in interactive modes).
+    Rekordbox is running (or prompts to continue in interactive modes), and
+    holds the single-writer advisory lock for the whole run.
     """
 
     def decorator(func):
@@ -132,7 +173,13 @@ def with_database(*, writes: bool = False):
             database_path: str | None = kwargs.pop("database_path", None)
             db = Rekordbox6Database(path=database_path)  # ty: ignore[invalid-argument-type]
             try:
-                return func(db=db, **kwargs)
+                if not writes:
+                    return func(db=db, **kwargs)
+                with _write_lock(db, kwargs):
+                    return func(db=db, **kwargs)
+            except DatabaseBusyError as e:
+                logger.error(str(e))
+                sys.exit(1)
             finally:
                 db.close()
 

--- a/rekordbox_edit/locking.py
+++ b/rekordbox_edit/locking.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 #: How long a non-interactive command waits for the lock. Interactive
 #: commands pass 0 so a user at a terminal fails fast instead of hanging.
-SCRIPTED_TIMEOUT = 5.0
+SCRIPTED_TIMEOUT = 30.0
 
 _LOCK_DIR = (
     Path(PlatformDirs(appname="rekordbox-edit", ensure_exists=True).user_data_dir)

--- a/rekordbox_edit/locking.py
+++ b/rekordbox_edit/locking.py
@@ -1,0 +1,107 @@
+"""Single-writer advisory lock over a rekordbox database directory.
+
+Concurrent rbe processes are not supported: two commands writing the same
+library can interleave their plan and apply phases and invalidate each
+other's operations. A write command holds this lock for its whole run, and
+a second process either waits briefly or fails with a message naming the
+holder.
+"""
+
+import hashlib
+import json
+import logging
+import os
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+from filelock import FileLock, Timeout
+from platformdirs import PlatformDirs
+
+logger = logging.getLogger(__name__)
+
+#: How long a non-interactive command waits for the lock. Interactive
+#: commands pass 0 so a user at a terminal fails fast instead of hanging.
+SCRIPTED_TIMEOUT = 5.0
+
+_LOCK_DIR = (
+    Path(PlatformDirs(appname="rekordbox-edit", ensure_exists=True).user_data_dir)
+    / "locks"
+)
+
+
+class DatabaseBusyError(RuntimeError):
+    """Another rbe process holds the write lock for this database."""
+
+
+def _lock_path(db_directory) -> Path:
+    """Return the lock file for a database directory.
+
+    Keyed by a digest of the directory so that --database-path targets and
+    the e2e fixture copies never contend with a real library.
+    """
+    digest = hashlib.sha256(str(db_directory).encode("utf-8")).hexdigest()[:16]
+    return _LOCK_DIR / f"{digest}.lock"
+
+
+def _holder_path(lock_path: Path) -> Path:
+    """Return the sidecar recording who holds `lock_path`.
+
+    Kept out of the lock file itself because filelock opens that file with
+    O_TRUNC, so a contending process would erase the record before its own
+    acquisition fails.
+    """
+    return lock_path.with_suffix(".holder.json")
+
+
+def _describe_holder(lock_path: Path) -> str:
+    """Describe the process holding `lock_path`, or "" if it cannot be read.
+
+    The holder may exit between the timeout and this read, so a missing or
+    malformed file is expected rather than exceptional.
+    """
+    try:
+        holder = json.loads(_holder_path(lock_path).read_text(encoding="utf-8"))
+        return f' (PID {holder["pid"]}, "{holder["command"]}", started {holder["started"]})'
+    except (OSError, ValueError, KeyError):
+        return ""
+
+
+@contextmanager
+def database_lock(db_directory, command: str, timeout: float) -> Iterator[None]:
+    """Hold the single-writer lock for `db_directory` for the duration of the block.
+
+    Raises DatabaseBusyError if the lock is not free within `timeout` seconds.
+    """
+    path = _lock_path(db_directory)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(str(path))
+    try:
+        lock.acquire(timeout=timeout)
+    except Timeout as e:
+        raise DatabaseBusyError(
+            f"Another rekordbox-edit process is writing to this library"
+            f"{_describe_holder(path)}. Wait for it to finish, then try again."
+        ) from e
+    logger.debug(f"Acquired write lock: {path}")
+    try:
+        # Best effort: the lock itself is the OS file lock, and this payload
+        # only exists to make the busy message name the holder.
+        _holder_path(path).write_text(
+            json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "command": command,
+                    "started": datetime.now().strftime("%H:%M:%S"),
+                }
+            ),
+            encoding="utf-8",
+        )
+    except OSError as e:
+        logger.debug(f"Could not record lock holder: {e}")
+    try:
+        yield
+    finally:
+        lock.release()
+        logger.debug(f"Released write lock: {path}")

--- a/tests/cli/test_locking.py
+++ b/tests/cli/test_locking.py
@@ -1,0 +1,168 @@
+"""Tests for the single-writer lock as wired into with_database."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from rekordbox_edit.cli.edit import edit_command
+from rekordbox_edit.cli.search import search_command
+from rekordbox_edit.locking import database_lock
+from rekordbox_edit.models import (
+    EditOp,
+    EditResponse,
+    EditResult,
+    SearchResponse,
+    Track,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_rekordbox_not_running():
+    with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+        yield
+
+
+def _response():
+    track = Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")
+    return EditResponse(
+        tracks=[track],
+        result=EditResult(
+            field="Title", edits=[EditOp(id="1", new_value="New")], skipped=[]
+        ),
+    )
+
+
+def _search_response():
+    track = Track(ID="1", Title="New", FileNameL="x.wav", FolderPath="/x.wav")
+    return SearchResponse(tracks=[track])
+
+
+@pytest.fixture
+def library(tmp_path):
+    """A stand-in database directory that every command in a test shares."""
+    return tmp_path / "rekordbox"
+
+
+class TestWriteLock:
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_write_command_fails_when_lock_is_held(
+        self, mock_db_class, mock_edit, library, caplog
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        with database_lock(library, command="convert", timeout=0):
+            result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code == 1
+        assert "Another rekordbox-edit process" in caplog.text
+        assert '"convert"' in caplog.text
+        mock_edit.assert_not_called()
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_dry_run_proceeds_while_lock_is_held(
+        self, mock_db_class, mock_edit, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        with database_lock(library, command="convert", timeout=0):
+            result = CliRunner().invoke(
+                edit_command, ["Title", "--replace", "New", "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        mock_edit.assert_called_once()
+
+    @patch("rekordbox_edit.cli.search.search")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_read_command_proceeds_while_lock_is_held(
+        self, mock_db_class, mock_search, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_search.return_value = _search_response()
+
+        with database_lock(library, command="convert", timeout=0):
+            result = CliRunner().invoke(search_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_lock_is_released_after_a_successful_run(
+        self, mock_db_class, mock_edit, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        with database_lock(library, command="convert", timeout=0):
+            pass
+
+    @patch("rekordbox_edit.cli.edit.edit", side_effect=RuntimeError("boom"))
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_lock_is_released_when_the_command_raises(
+        self, mock_db_class, mock_edit, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        with database_lock(library, command="convert", timeout=0):
+            pass
+
+
+class TestWaitBudget:
+    """Interactive runs fail on the spot; --yes runs wait for the lock."""
+
+    @patch("rekordbox_edit.cli._utils.database_lock")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_scripted_run_waits(self, mock_db_class, mock_edit, mock_lock, library):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        assert mock_lock.call_args.kwargs["timeout"] == 5.0
+
+    @patch("rekordbox_edit.cli._utils.database_lock")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_interactive_run_does_not_wait(
+        self, mock_db_class, mock_edit, mock_lock, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New"], input="n\n")
+
+        assert mock_lock.call_args.kwargs["timeout"] == 0
+
+    @patch("rekordbox_edit.cli._utils.database_lock")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_lock_records_the_subcommand_name(
+        self, mock_db_class, mock_edit, mock_lock, library
+    ):
+        mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
+        mock_edit.return_value = _response()
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        assert mock_lock.call_args.kwargs["command"] == "edit"
+
+
+class TestBusyTimeout:
+    def test_pragma_is_applied_to_new_sqlite_connections(self, tmp_path):
+        from sqlalchemy import create_engine, text
+
+        from rekordbox_edit.cli._utils import BUSY_TIMEOUT_MS
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'probe.db'}")
+        with engine.connect() as conn:
+            assert conn.execute(text("PRAGMA busy_timeout")).scalar() == BUSY_TIMEOUT_MS

--- a/tests/cli/test_locking.py
+++ b/tests/cli/test_locking.py
@@ -128,7 +128,7 @@ class TestWaitBudget:
 
         CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
 
-        assert mock_lock.call_args.kwargs["timeout"] == 5.0
+        assert mock_lock.call_args.kwargs["timeout"] == 30.0
 
     @patch("rekordbox_edit.cli._utils.database_lock")
     @patch("rekordbox_edit.cli.edit.edit")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,15 @@ from unittest.mock import MagicMock
 import pytest
 from pyrekordbox.db6 import DjmdContent
 
+from rekordbox_edit import locking
+
 from rekordbox_edit.models import Track
+
+
+@pytest.fixture(autouse=True)
+def isolated_lock_dir(tmp_path, monkeypatch):
+    """Keep write-lock files out of the real user data directory during tests."""
+    monkeypatch.setattr(locking, "_LOCK_DIR", tmp_path / "locks")
 
 
 @pytest.fixture

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,93 @@
+import json
+import logging
+import os
+
+import pytest
+
+from rekordbox_edit import locking
+from rekordbox_edit.locking import (
+    DatabaseBusyError,
+    _holder_path,
+    _lock_path,
+    database_lock,
+)
+
+
+class TestLockPath:
+    def test_distinct_directories_get_distinct_locks(self):
+        assert _lock_path("/a/rekordbox") != _lock_path("/b/rekordbox")
+
+    def test_same_directory_is_stable(self):
+        assert _lock_path("/a/rekordbox") == _lock_path("/a/rekordbox")
+
+
+class TestDatabaseLock:
+    def test_second_acquisition_raises_while_held(self, tmp_path):
+        with database_lock(tmp_path, command="convert", timeout=0):
+            with pytest.raises(DatabaseBusyError):
+                with database_lock(tmp_path, command="edit", timeout=0):
+                    pass
+
+    def test_lock_is_released_on_exit(self, tmp_path):
+        with database_lock(tmp_path, command="convert", timeout=0):
+            pass
+        with database_lock(tmp_path, command="edit", timeout=0):
+            pass
+
+    def test_lock_is_released_when_body_raises(self, tmp_path):
+        with pytest.raises(RuntimeError):
+            with database_lock(tmp_path, command="convert", timeout=0):
+                raise RuntimeError("boom")
+        with database_lock(tmp_path, command="edit", timeout=0):
+            pass
+
+    def test_different_directories_do_not_contend(self, tmp_path):
+        with database_lock(tmp_path / "a", command="convert", timeout=0):
+            with database_lock(tmp_path / "b", command="edit", timeout=0):
+                pass
+
+    def test_busy_message_names_the_holder(self, tmp_path):
+        with database_lock(tmp_path, command="convert", timeout=0):
+            with pytest.raises(DatabaseBusyError) as excinfo:
+                with database_lock(tmp_path, command="edit", timeout=0):
+                    pass
+        message = str(excinfo.value)
+        assert f"PID {os.getpid()}" in message
+        assert '"convert"' in message
+
+    def test_busy_message_falls_back_when_holder_unreadable(self, tmp_path):
+        with database_lock(tmp_path, command="convert", timeout=0):
+            _holder_path(_lock_path(tmp_path)).write_text("not json", encoding="utf-8")
+            with pytest.raises(DatabaseBusyError) as excinfo:
+                with database_lock(tmp_path, command="edit", timeout=0):
+                    pass
+        assert "Another rekordbox-edit process" in str(excinfo.value)
+        assert "PID" not in str(excinfo.value)
+
+    def test_an_unwritable_holder_record_does_not_cost_the_lock(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The sidecar only enriches the busy message, so a filesystem that
+        # refuses it must not stop the caller from holding the lock.
+        monkeypatch.setattr(
+            locking, "_holder_path", lambda path: tmp_path / "absent" / "holder.json"
+        )
+
+        held = False
+        with caplog.at_level(logging.DEBUG, logger="rekordbox_edit.locking"):
+            with database_lock(tmp_path, command="convert", timeout=0):
+                held = True
+
+        assert held
+        assert "Could not record lock holder" in caplog.text
+        # The release path still ran, so the next acquisition succeeds.
+        with database_lock(tmp_path, command="edit", timeout=0):
+            pass
+
+    def test_holder_payload_records_the_command(self, tmp_path):
+        with database_lock(tmp_path, command="import", timeout=0):
+            holder = json.loads(
+                _holder_path(_lock_path(tmp_path)).read_text(encoding="utf-8")
+            )
+        assert holder["command"] == "import"
+        assert holder["pid"] == os.getpid()

--- a/uv.lock
+++ b/uv.lock
@@ -1282,6 +1282,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "ffmpeg-python" },
+    { name = "filelock" },
     { name = "mutagen" },
     { name = "platformdirs" },
     { name = "pydantic" },
@@ -1314,6 +1315,7 @@ docs = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0,<=9.0.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
+    { name = "filelock", specifier = ">=3.13,<4" },
     { name = "mutagen", specifier = ">=1.48.1" },
     { name = "platformdirs", specifier = ">=4.3.8,<5.0.0" },
     { name = "pydantic", specifier = ">=2.0,<3" },


### PR DESCRIPTION
First of three PRs trying to improve concurrency reslience.

- New `rekordbox_edit/locking.py`: an advisory `filelock` keyed to a digest of the database directory, so `--database-path` targets and e2e fixture copies never contend with a library in the default path.
- `with_database(writes=True)` acquires it once and holds it for the whole run.
- Interactive runs use `timeout=0` and fail immediately; `--yes` runs wait 30s.
- Dry runs and `search` never acquire it, so you can plan one operation while another runs.
- Busy error names the holder: `Another rekordbox-edit process is writing to this library (PID 41207, "convert", started 14:02:31)`.
- `PRAGMA busy_timeout = 5000` so a write contended by Rekordbox itself waits instead of raising `OperationalError`.
- FAQ entry documenting the behavior.

## Notes

- The holder record lives in a `.holder.json` sidecar, not the lock file: `filelock` opens the lock file `O_TRUNC`, so a contender erased the record before its own acquisition failed.
- The pragma is bound to the `Engine` class rather than an instance. pyrekordbox builds the engine and connects lazily, leaving no point to attach a per-instance listener, and per-instance `listens_for` rejects the `Mock` used by 70 existing CLI tests. Class-level is SQLAlchemy's documented pattern for SQLite pragmas.
- Adds `filelock` as an explicit runtime dependency (already present transitively).